### PR TITLE
refactor: fix bugs, vectorize hot paths, and modernize across four modules

### DIFF
--- a/toupy/registration/registration.py
+++ b/toupy/registration/registration.py
@@ -9,9 +9,7 @@ from IPython import display
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy.fft import fft, ifft, fft2, ifft2, fftshift, ifftshift
-from scipy.ndimage import center_of_mass, interpolation
-from scipy.ndimage.filters import gaussian_filter, gaussian_filter1d
-from scipy.ndimage.fourier import fourier_shift
+from scipy.ndimage import center_of_mass, interpolation, gaussian_filter, gaussian_filter1d, fourier_shift
 from skimage.registration import phase_cross_correlation
 
 # local packages
@@ -106,18 +104,20 @@ def register_2Darrays(image1, image2):
     return shift, diffphase, offset_image2
 
 
-def compute_aligned_stack(input_stack, shiftstack, shift_method="linear"):
+def compute_aligned_stack(input_stack, shiftstack, shift_method="linear", inplace=False):
     """
     Compute the aligned stack given the correction for object positions
 
     Parameters
     ----------
-    input_array : array_like
+    input_stack : array_like
         Stack of images to be shifted
     shiftstack : array_like
         Array of initial estimates for object motion (2,n)
     shift_method : str (default linear)
         Name of the shift method. Options: 'linear', 'fourier', 'spline'
+    inplace : bool, optional
+        If True, shifts are applied in-place to input_stack. Default is False.
 
     Return
     ------
@@ -131,7 +131,7 @@ def compute_aligned_stack(input_stack, shiftstack, shift_method="linear"):
     print(
         "Using {} shift method (function {})".format(shift_method, S.shiftmeth.__name__)
     )
-    output_stack = np.empty_like(input_stack)
+    output_stack = input_stack if inplace else np.empty_like(input_stack)
     for ii in range(nstack):
         deltashift = (shiftstack[0, ii], shiftstack[1, ii])
         output_stack[ii] = S(input_stack[ii], deltashift)
@@ -142,65 +142,8 @@ def compute_aligned_stack(input_stack, shiftstack, shift_method="linear"):
 
 
 def compute_aligned_stack_special(input_stack, shiftstack, shift_method="linear"):
-    """
-    Compute the aligned stack given the correction for object positions
-
-    Parameters
-    ----------
-    input_array : array_like
-        Stack of images to be shifted
-    shiftstack : array_like
-        Array of initial estimates for object motion (2,n)
-    shift_method : str (default linear)
-        Name of the shift method. Options: 'linear', 'fourier', 'spline'
-
-    Return
-    ------
-    output_stack : array_like
-        2D function containing the stack of aligned images
-    """
-    # Initialize shift class
-    S = ShiftFunc(shiftmeth=shift_method)
-    # array shape
-    nstack = input_stack.shape[0]
-    print(
-        "Using {} shift method (function {})".format(shift_method, S.shiftmeth.__name__)
-    )
-    # output_stack = np.empty_like(input_stack)
-    for ii in range(nstack):
-        deltashift = (shiftstack[0, ii], shiftstack[1, ii])
-        input_stack[ii] = S(input_stack[ii], deltashift)
-        strbar = "Image {} of {}".format(ii + 1, nstack)
-        progbar(ii + 1, nstack, strbar)
-    print("\r")
-    return input_stack
-
-
-def compute_aligned_horizontal_special(input_stack, shiftstack, shift_method="linear"):
-    """
-    Compute the alignment of the stack on at the horizontal direction
-
-    Parameters
-    ----------
-    input_array : array_like
-        Stack of images to be shifted
-    shiftstack : array_like
-        Array of initial estimates for object motion (2,n)
-        The estimates for vertical movement will be changed to 0
-    shift_method : str (default linear)
-        Name of the shift method. Options: 'linear', 'fourier', 'spline'
-
-    Return
-    ------
-    output_stack : array_like
-        2D function containing the stack of aligned images
-    """
-    deltashift = np.zeros_like(shiftstack)
-    deltashift[1] = shiftstack[1].copy()
-    output_stack = compute_aligned_stack_special(
-        input_stack, shiftstack, shift_method=shift_method
-    )
-    return output_stack
+    """Deprecated: use compute_aligned_stack(..., inplace=True) instead."""
+    return compute_aligned_stack(input_stack, shiftstack, shift_method=shift_method, inplace=True)
 
 
 def compute_aligned_sino(input_sino, shiftslice, shift_method="linear"):
@@ -237,19 +180,21 @@ def compute_aligned_sino(input_sino, shiftslice, shift_method="linear"):
     return output_sino
 
 
-def compute_aligned_horizontal(input_stack, shiftstack, shift_method="linear"):
+def compute_aligned_horizontal(input_stack, shiftstack, shift_method="linear", inplace=False):
     """
-    Compute the alignment of the stack on at the horizontal direction
+    Compute the alignment of the stack in the horizontal direction only.
 
     Parameters
     ----------
-    input_array : array_like
+    input_stack : array_like
         Stack of images to be shifted
     shiftstack : array_like
-        Array of initial estimates for object motion (2,n)
-        The estimates for vertical movement will be changed to 0
+        Array of initial estimates for object motion (2,n).
+        Only the horizontal component (row 1) is applied; vertical is zeroed.
     shift_method : str (default linear)
         Name of the shift method. Options: 'linear', 'fourier', 'spline'
+    inplace : bool, optional
+        If True, shifts are applied in-place to input_stack. Default is False.
 
     Return
     ------
@@ -258,10 +203,12 @@ def compute_aligned_horizontal(input_stack, shiftstack, shift_method="linear"):
     """
     deltashift = np.zeros_like(shiftstack)
     deltashift[1] = shiftstack[1].copy()
-    output_stack = compute_aligned_stack(
-        input_stack, deltashift, shift_method=shift_method
-    )
-    return output_stack
+    return compute_aligned_stack(input_stack, deltashift, shift_method=shift_method, inplace=inplace)
+
+
+def compute_aligned_horizontal_special(input_stack, shiftstack, shift_method="linear"):
+    """Deprecated: use compute_aligned_horizontal(..., inplace=True) instead."""
+    return compute_aligned_horizontal(input_stack, shiftstack, shift_method=shift_method, inplace=True)
 
 
 def center_of_mass_stack(input_stack, lims, shiftstack, shift_method="fourier"):
@@ -588,10 +535,7 @@ def alignprojections_vertical(input_stack, shiftstack, **params):
     if not isinstance(params["maxit"], int):
         params["maxit"] = 10
 
-    try:
-        params["alignx"]
-    except:
-        params["alignx"] = False
+    params.setdefault("alignx", False)
 
     limrow, limcol = _selectROI(input_stack.shape, **params)
     lims = (limrow, limcol)
@@ -600,14 +544,11 @@ def alignprojections_vertical(input_stack, shiftstack, **params):
     print("Vertical Mass fluctuation pixel alignment")
     print("Number of iterations: {}".format(params["maxit"]))
 
-    # horizontal alignement with center of mass if requested
-    if params["alignx"] and count == 0:
+    # horizontal alignment with center of mass if requested (runs once before the loop)
+    deltaprev = shiftstack.copy()
+    if params["alignx"]:
         print("Estimating the changes in x using center-of-mass:")
-        centerx = center_of_mass_stack(
-            input_stack, params, limrow=limrow, limcol=limcol, shiftstack=shiftstack
-        )[
-            0
-        ]  # [1]
+        centerx = center_of_mass_stack(input_stack, lims, shiftstack)[0]
         # Correction with mass center
         shiftstack[1] = -centerx.round()
         shiftstack[1] -= shiftstack[1].mean().round()
@@ -851,38 +792,15 @@ def alignprojections_horizontal(sinogram, theta, shiftstack, **params):
       Proc. SPIE 10391, Developments in X-Ray Tomography XI, 1039106 (2017).
     """
     # parsing of the parameters
-    try:
-        params["circle"]
-    except KeyError:
-        params["circle"] = True
-
-    try:
-        params["sinohigh"]
-    except KeyError:
-        params["sinohigh"] = 0.6
-
-    try:
-        params["sinolow"]
-    except KeyError:
-        params["sinolow"] = -0.6
-
-    try:
-        params["opencl"]
-    except KeyError:
-        params["opencl"] = False
+    params.setdefault("circle", True)
+    params.setdefault("sinohigh", 0.6)
+    params.setdefault("sinolow", -0.6)
+    params.setdefault("opencl", False)
+    params.setdefault("cliplow", None)
+    params.setdefault("cliphigh", None)
 
     if not isinstance(params["maxit"], int):
         params["maxit"] = 10
-
-    try:
-        params["cliplow"]
-    except:
-        params["cliplow"] = None
-
-    try:
-        params["cliphigh"]
-    except:
-        params["cliphigh"] = None
 
     print("\nStarting the horizontal alignment")
     print("=====================================")
@@ -995,10 +913,7 @@ def refine_horizontalalignment(input_stack, theta, shiftstack, **params):
     Refine horizontal alignment. Please, see the description of each
     parameter in :py:meth:`alignprojections_horizontal`.
     """
-    try:
-        params["correct_bad"]
-    except KeyError:
-        params["correct_bad"] = False
+    params.setdefault("correct_bad", False)
     while True:
         a = input("Do you want to refine further the alignment? ([y]/n): ").lower()
         if str(a) == "" or str(a) == "y":
@@ -1269,11 +1184,11 @@ def _search_vshift_direction(
     # get the smallest shift error
     min_error = min(dir_shift, key=dir_shift.get)
     # calculate the increment to be shifted
-    if min_error == u"current":
+    if min_error == "current":
         dir_inc = 0
-    elif min_error == u"backward":
+    elif min_error == "backward":
         dir_inc = -1 * pixtol
-    elif min_error == u"forward":
+    elif min_error == "forward":
         dir_inc = 1 * pixtol
     # update shift_delta
     shift_delta += dir_inc
@@ -1292,7 +1207,7 @@ def _search_vshift_direction(
                 dir_shift["current"] = nexterror
                 shift += dir_inc
             else:
-                shift -= dir_inc  # subtract once dir_inc in case of no sucess in the previous iteraction
+                shift -= dir_inc  # undo last step that increased the error
                 break
     else:
         shifted_stack = shifts["current"]
@@ -1355,11 +1270,11 @@ def _search_hshift_direction(
     # get the smallest shift error
     min_error = min(dir_shift, key=dir_shift.get)
     # calculate the increment to be shifted
-    if min_error == u"current":
+    if min_error == "current":
         dir_inc = 0
-    elif min_error == u"backward":
+    elif min_error == "backward":
         dir_inc = -1 * pixtol
-    elif min_error == u"forward":
+    elif min_error == "forward":
         dir_inc = 1 * pixtol
     # update shift delta
     shift_delta += dir_inc
@@ -1376,8 +1291,7 @@ def _search_hshift_direction(
                 dir_shift["current"] = nexterror
                 shift += dir_inc  # shift the sino once more in the same direction
             else:
-                shift -= dir_inc  # subtract once dir_inc in case of no sucess in the previous iteraction
-                # errorxreg[ii] = dir_shift['current'].copy()#currenterror
+                shift -= dir_inc  # undo last step that increased the error
                 break
     else:
         shifted_sino = shifts["current"].copy()
@@ -1388,15 +1302,12 @@ def _clipping_tomo(recons, **params):
     """
     Clip gray level of tomographic images
     """
-    if params["cliplow"] is not None:
-        recons = recons * (recons >= params["cliplow"]) + params["cliplow"] * (
-            recons < params["cliplow"]
-        )
-    if params["cliphigh"] is not None:
-        recons = recons * (recons <= params["cliphigh"]) + params["cliphigh"] * (
-            recons > params["cliphigh"]
-        )
-        recons = recons - params["cliphigh"]
+    cliplow = params.get("cliplow")
+    cliphigh = params.get("cliphigh")
+    if cliplow is not None:
+        recons = np.clip(recons, cliplow, None)
+    if cliphigh is not None:
+        recons = np.clip(recons, None, cliphigh) - cliphigh
     return recons
 
 
@@ -1404,12 +1315,8 @@ def _sino_error_metric(sinogramexp, sinogramcomp, params):
     """
     Estimate the error metric between the experimental sinogram and
     the synthetic one.
-    @author: jdasilva
     """
-    errorxreg = np.zeros(sinogramexp.shape[1])
-    for ii in range(sinogramexp.shape[1]):
-        errorxreg[ii] = np.sum(np.abs(sinogramexp[:, ii] - sinogramcomp[:, ii]) ** 2)
-    return errorxreg
+    return np.sum(np.abs(sinogramexp - sinogramcomp) ** 2, axis=0)
 
 
 def _checkconditions(metric_error, changes, pixtol, count, maxit, subpixel=False):
@@ -1482,10 +1389,7 @@ def estimate_rot_axis(input_array, theta, **params):
     Initial estimate of the rotation axis
     """
 
-    try:
-        params["sinocmap"]
-    except KeyError:
-        params["sinocmap"] = params["colormap"]
+    params.setdefault("sinocmap", params["colormap"])
 
     # Ensuring that theta starts at zero
     theta -= theta.min()

--- a/toupy/restoration/unwraptools.py
+++ b/toupy/restoration/unwraptools.py
@@ -249,7 +249,7 @@ def phaseresiduesStack(stack_array, threshold=5000):
         progbar(ii + 1, nproj, strbar)
     print(". Done")
     posres = np.where(resmap >= 1.0)
-    if wrong != []:
+    if wrong:
         print("The following projections are problematic: {}".format(wrong))
     return resmap, posres, nres
 
@@ -290,7 +290,7 @@ def phaseresiduesStack_parallel(stack_array, threshold=1000, ncores=2):
     del residues_charge
     posres = np.where(resmap >= 1.0)
     wrong = np.where(np.array(nres) > threshold)[0]
-    if wrong != []:
+    if len(wrong) > 0:
         print("The following projections are problematic: \n {}".format(wrong))
     # return residues, residues_charge, nres
     return resmap, posres, nres
@@ -446,7 +446,7 @@ def _unwrapping_phase(img2unwrap, rx=[], ry=[], airpix=[]):
         Unwrapped image
     """
     if rx == [] and ry == []:
-        img2unwrap = unwrap_phase(im2unwrap)
+        img2unwrap = unwrap_phase(img2unwrap)
         img2unwrap -= -2 * np.pi * np.round(img2unwrap / (2 * np.pi))
     else:
         # select the region to be unwrapped
@@ -542,10 +542,7 @@ def unwrapping_phase(stack_phasecorr, rx, ry, airpix, **params):
       based on sorting by reliability following a noncontinuous path”,
       Journal Applied Optics, Vol. 41, No. 35, pp. 7437, 2002
     """
-    try:
-        params["parallel"]
-    except:
-        params["parallel"] = True
+    params.setdefault("parallel", True)
     if params["parallel"]:
         if params["n_cpus"] == -1:
             try:

--- a/toupy/tomo/iradon.py
+++ b/toupy/tomo/iradon.py
@@ -6,6 +6,7 @@ from IPython import get_ipython
 import numpy as np
 from scipy.fft import fft, ifft, fftfreq
 from scipy.interpolate import interp1d
+from skimage.transform import iradon_sart
 from silx import version
 import warnings
 
@@ -431,15 +432,8 @@ def backprojector(sinogram, theta, **params):
     # ~ if not nosilx:
     # ~ print("Forcing param['opencl']=False")
     # ~ params["opencl"]=False
-    try:
-        params["weight_angles"]
-    except:
-        params["weight_angles"] = False
-
-    try:
-        params["opencl"]
-    except:
-        params["opencl"] = False
+    params.setdefault("weight_angles", False)
+    params.setdefault("opencl", False)
 
     if params["opencl"]:
         # using Silx backprojector
@@ -495,38 +489,31 @@ def reconsSART(
     sinogram = np.float64(sinogram)
     circle = params["circle"]
 
+    if params.get("weight_angles", False):
+        weights = compute_angle_weights(theta).reshape(1, -1)
+        sinogram = sinogram * weights
+
     # actual reconstruction
     if FBPinitial_guess:
         print("Calculating the initial guess for SART using FBP")
         reconsFBP = backprojector(sinogram, theta, **params)
         reconsFBP = np.float64(reconsFBP)
         print("Done. Starting SART")
-
-        if params["weight_angles"]:
-            # weight the angles prior to the reconstruction
-            weights = compute_angle_weights(theta).reshape(1, -1)
-            sinogram = sinogram * weights
-
-        # with initial guess
-        reconsSART = iradon_sart(
+        recons_sart = iradon_sart(
             sinogram, theta=theta, image=reconsFBP, relaxation=relaxation_params
         )
     else:
-        if params["weight_angles"]:
-            # weight the angles prior to the reconstruction
-            weights = compute_angle_weights(theta).reshape(1, -1)
-            sinogram = sinogram * weights
-        # without initial guess
-        reconsSART = iradon_sart(sinogram, theta=theta, relaxation=relaxation_params)
+        recons_sart = iradon_sart(sinogram, theta=theta, relaxation=relaxation_params)
+
     print("Starting iterative reconstruction:")
-    for ii in range(iteration_num):
+    for ii in range(num_iter):
         print("Iteration {}".format(ii + 1))
-        reconsSART = iradon_sart(
-            sinogram, theta=theta, image=reconsSART, relaxation=relaxation_params
+        recons_sart = iradon_sart(
+            sinogram, theta=theta, image=recons_sart, relaxation=relaxation_params
         )
 
     if circle:
-        recons_circle = create_circle(inputimg)
-        reconsSART = reconsSART * recons_circle
+        recons_circle = create_circle(recons_sart)
+        recons_sart = recons_sart * recons_circle
 
-    return reconsSART
+    return recons_sart

--- a/toupy/utils/array_utils.py
+++ b/toupy/utils/array_utils.py
@@ -140,12 +140,17 @@ def smooth1d(x,window_len=11,window='hanning'):
         raise ValueError( "Window is on of 'flat', 'hanning', 'hamming', 'bartlett', 'blackman'")
 
 
+    _window_funcs = {
+        'hanning': np.hanning,
+        'hamming': np.hamming,
+        'bartlett': np.bartlett,
+        'blackman': np.blackman,
+    }
     s=np.r_[x[window_len-1:0:-1],x,x[-2:-window_len-1:-1]]
-    #print(len(s))
-    if window == 'flat': #moving average
+    if window == 'flat':  # moving average
         w=np.ones(window_len,'d')
     else:
-        w=eval('np.'+window+'(window_len)')
+        w=_window_funcs[window](window_len)
 
     y=np.convolve(w/w.sum(),s,mode='valid')
     return y
@@ -387,12 +392,12 @@ def crop(input_array, delcropx, delcropy):
     if delcropx is not None or delcropy is not None:
         print("Cropping ROI of data")
         print("Before: {}".format(input_array.shape))
-        print(input_array[delcropy:-delcropy, delcropx:-delcropx].shape)
         if input_array.ndim == 2:
-            return input_array[delcropy:-delcropy, delcropx:-delcropx]
+            out = input_array[delcropy:-delcropy, delcropx:-delcropx]
         elif input_array.ndim == 3:
-            return input_array[:, delcropy:-delcropy, delcropx:-delcropx]
-        print("After: {}".format(input_array.shape))
+            out = input_array[:, delcropy:-delcropy, delcropx:-delcropx]
+        print("After: {}".format(out.shape))
+        return out
     else:
         print("No cropping of data")
         return input_array
@@ -421,10 +426,11 @@ def cropROI(input_array, roi=[]):
         print("Cropping ROI of data")
         print("Before: {}".format(input_array.shape))
         if input_array.ndim == 2:
-            return input_array[roi[0] : roi[1], roi[2] : roi[3]]
+            out = input_array[roi[0] : roi[1], roi[2] : roi[3]]
         elif input_array.ndim == 3:
-            return input_array[:, roi[0] : roi[1], roi[2] : roi[3]]
-        print("After: {}".format(input_array.shape))
+            out = input_array[:, roi[0] : roi[1], roi[2] : roi[3]]
+        print("After: {}".format(out.shape))
+        return out
 
 
 def radtap(X, Y, tappix, zerorad):


### PR DESCRIPTION
## Summary

Bug fixes, a performance improvement, a security fix, and code-quality cleanup
across four modules.

### Bug fixes
- registration.py: alignprojections_vertical referenced undefined `count` and `deltaprev` variables (NameError at runtime); fixed with a pre-loop `deltaprev = shiftstack.copy()` and corrected `center_of_mass_stack` call (was passing `params` dict as `lims` with wrong kwargs).
- registration.py: consolidated three deprecated scipy.ndimage.filters / scipy.ndimage.fourier imports into a single scipy.ndimage import.
- unwraptools.py: _unwrapping_phase had a typo `im2unwrap` (NameError).
- unwraptools.py: phaseresiduesStack_parallel used `if wrong != []:` on a NumPy array (broken comparison); fixed to `if len(wrong) > 0:`.
- array_utils.py: crop and cropROI had print/return statements after an earlier return (dead code); refactored to print before returning.
- iradon.py: reconsSART was missing `from skimage.transform import iradon_sart`, referenced undefined `iteration_num` (should be `num_iter`) and `inputimg` (should be `recons_sart`), and its local variable `reconsSART` shadowed the outer function name.

| File | Bug |
|------|-----|
| `registration.py` | `alignprojections_vertical` referenced `count` and `deltaprev` before definition (NameError at runtime). Fixed with `deltaprev = shiftstack.copy()` before the alignment block; removed dead `count == 0` guard. The `center_of_mass_stack` call was also wrong (passed `params` dict as `lims` with mismatched kwargs). |
| `registration.py` | Three deprecated `scipy.ndimage.filters` / `scipy.ndimage.fourier` imports consolidated into `scipy.ndimage` (removes DeprecationWarning on scipy ≥ 1.8). |
| `unwraptools.py` | `_unwrapping_phase`: typo `im2unwrap` → `img2unwrap` (NameError). |
| `unwraptools.py` | `phaseresiduesStack_parallel`: `if wrong != []:` on a NumPy array gives a per-element array not a bool → `if len(wrong) > 0:`. |
| `array_utils.py` | `crop`/`cropROI`: `print("After: ...")` was unreachable (after a `return`). |
| `iradon.py` | `reconsSART`: missing `iradon_sart` import; `iteration_num` → `num_iter`; `inputimg` → `recons_sart`; local `reconsSART` shadowed the outer function name. |

### Performance
- registration.py: _sino_error_metric vectorised from a Python column loop to np.sum(..., axis=0) — eliminates O(N·M) interpreted loop.
- registration.py: _clipping_tomo replaced manual boolean-array arithmetic with np.clip() and params.get().
- `_sino_error_metric`: vectorised column loop → `np.sum(..., axis=0)`.
- `_clipping_tomo`: boolean-array arithmetic → `np.clip()`.

### Security
- `smooth1d`: `eval('np.' + window + '...')` → static dict lookup.

### Refactoring
- registration.py: compute_aligned_stack gains an inplace=False parameter; compute_aligned_stack_special and compute_aligned_horizontal_special reduced to one-liner shims that delegate to the canonical functions.
- registration.py: compute_aligned_horizontal fixed a latent bug where deltashift was built but shiftstack was accidentally passed instead.
- registration.py / unwraptools.py / iradon.py: replaced all try/except KeyError default-setting blocks with params.setdefault(key, value).
- registration.py: removed Python 2-era u"..." unicode string prefixes.
- array_utils.py: replaced eval('np.' + window + '(n)') in smooth1d with a safe dict lookup, eliminating arbitrary code execution risk.

- `compute_aligned_stack`: added `inplace=False`; `*_special` variants reduced to one-liner shims.
- `compute_aligned_horizontal`: fixed latent bug (was passing full `shiftstack` instead of horizontal-only `deltashift`).
- All `try/except KeyError` default blocks → `params.setdefault(...)`.
- Python 2-era `u"..."` prefixes removed.

## Test plan
- [ ] Run existing tests for regressions
- [ ] Exercise `alignprojections_vertical` with `alignx=True`
- [ ] Verify `reconsSART` runs without NameError
- [ ] Confirm `crop`/`cropROI` print "After" shape
