### PR TITLE
fix: remove duplicate figure display in Jupyter notebook

### DIFF
--- a/toupy/registration/registration.py
+++ b/toupy/registration/registration.py
@@ -1082,7 +1082,6 @@ def tomoconsistency_multiple(input_stack, theta, shiftstack, **params):
     if isnotebook():
         from IPython import display
         display.display(fig)
-        display.display(fig.canvas)
     else:
         plt.show(block=False)
     a = input(
@@ -1435,7 +1434,6 @@ def estimate_rot_axis(input_array, theta, **params):
         if isnotebook():
             from IPython import display
             display.display(fig1)
-            display.display(fig1.canvas)
             display.clear_output(wait=True)
         else:
             # fig1.show(block=False)

--- a/toupy/restoration/GUI_tracker.py
+++ b/toupy/restoration/GUI_tracker.py
@@ -182,7 +182,6 @@ def gui_plotamp(stack_objs, **params):
     if isnotebook():
         from IPython import display
         display.display(fig)
-        display.display(fig.canvas)
         # display.clear_output(wait=True)
     else:
         fig.show()
@@ -326,7 +325,6 @@ def gui_plotphase(stack_objs, **params):
     if isnotebook():
         from IPython import display
         display.display(fig)
-        display.display(fig.canvas)
         # display.clear_output(wait=True)
     else:
         fig.show()

--- a/toupy/restoration/derivativetools.py
+++ b/toupy/restoration/derivativetools.py
@@ -65,7 +65,6 @@ def chooseregiontoderivatives(stack_array, **params):
         if isnotebook():
             from IPython import display
             display.display(fig)
-            display.display(fig.canvas)
         else:
             plt.show(block=False)
 

--- a/toupy/restoration/unwraptools.py
+++ b/toupy/restoration/unwraptools.py
@@ -347,7 +347,6 @@ def chooseregiontounwrap(stack_array, threshold=5000, parallel=False, ncores=1):
     if isnotebook():
         from IPython import display
         display.display(fig)
-        display.display(fig.canvas)
         # display.clear_output(wait=True)
     else:
         plt.show(block=False)
@@ -415,7 +414,6 @@ def chooseregiontounwrap(stack_array, threshold=5000, parallel=False, ncores=1):
         ax1.set_title("First projection with boundaries")
         if isnotebook():
             display.display(fig)
-            display.display(fig.canvas)
         else:
             plt.show(block=False)
 
@@ -571,7 +569,6 @@ def unwrapping_phase(stack_phasecorr, rx, ry, airpix, **params):
     if isnotebook():
         from IPython import display
         display.display(fig)
-        display.display(fig.canvas)
         display.clear_output(wait=True)
     else:
         plt.show(block=False)

--- a/toupy/utils/plot_utils.py
+++ b/toupy/utils/plot_utils.py
@@ -788,8 +788,8 @@ def iterative_show(
         im1.set_data(projection)
         ax1.set_title("Projection {}".format(ii + 1))
         if isnotebook():
+            display.clear_output(wait=True)
             display.display(fig)
-            display.display(fig.canvas)
         else:
             fig.show()
         plt.pause(0.001)


### PR DESCRIPTION
Each affected site was calling both display.display(fig) and display.display(fig.canvas), causing every figure to render twice — once as a static PNG and once as a canvas widget.

Remove all display.display(fig.canvas) calls; display.display(fig) alone is sufficient for both %matplotlib inline and widget backends.

Also add display.clear_output(wait=True) before the display.display(fig) call inside the projection slideshow loop in plot_utils.py so frames replace each other instead of stacking.

Affected files: registration.py, derivativetools.py, GUI_tracker.py, unwraptools.py, plot_utils.py