### PR TITLE
Fixes in the documentations and readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# ReadTheDocs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html
+
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: docs/source/conf.py
+  fail_on_warning: false
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -84,7 +84,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # Common abreviations
 rst_epilog = """
@@ -255,8 +255,10 @@ todo_include_todos = True
 # intersphinx_mapping = {'https://docs.python.org/': None}
 
 intersphinx_mapping = {
-    "https://docs.python.org/": None,
-    #'toupy': ('https://github.com/jcesardasilva/toupy.git', None),
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy", None),
+    "matplotlib": ("https://matplotlib.org/stable", None),
 }
 
 # import os


### PR DESCRIPTION
Add .readthedocs.yaml config file (required by RTD)
ReadTheDocs now requires an explicit .readthedocs.yaml at the repo root.
- Uses Ubuntu 24.04 + Python 3.11 build image
- Points Sphinx at docs/source/conf.py
- Installs toupy with the [docs] extras (sphinx + sphinx-rtd-theme)

docs: fix Sphinx 9 config errors in conf.py
- language = None → "en" (None invalid in Sphinx 5+)
- intersphinx_mapping: use named keys with (url, None) tuples
  (bare URL string key was invalid since Sphinx 5)
- Add numpy/scipy/matplotlib intersphinx targets