### PR TITLE
Phase retrieval, ring correction and TV reconstruction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,18 @@ tutorial/*.npz
 tutorial/*.png
 tutorial/*.txt
 tutorial/.ipynb_checkpoints
+
+# Generated figures from the example scripts (run anywhere)
+phase_true.png
+phase_retrieval_comparison.png
+sinogram_comparison.png
+ring_correction_comparison.png
+full_pipeline_comparison.png
+iterative_phase_retrieval.png
+iterative_phase_profile.png
+iterative_phase_tomography.png
+iterative_phase_tomography_profile.png
+ctf_frequency_coverage.png
+
+# Local Claude Code worktrees / session data
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+## Unreleased — phase retrieval, ring correction, TV reconstruction
+
+New methods for propagation-based / holotomographic X-ray nanotomography.
+All new compute functions accept `cuda=True` for optional GPU acceleration via
+CuPy, with automatic CPU fallback when CuPy is not installed.
+
+### Added — phase retrieval (`toupy.restoration`)
+
+- **`tie_hom`** — single-distance TIE-Hom (Paganin) phase retrieval for a
+  homogeneous object (fixed δ/β).
+- **`ctf_retrieve`** — CTF phase retrieval, unified for:
+  - single distance (2-D image) and batches of independent projections;
+  - **multi-distance / holotomographic** inversion (pass a list of distances +
+    a stack), which fills the single-distance CTF zeros and — through the
+    absorption term (`delta_beta`) — recovers low frequencies / DC.
+  - Sign convention fixed: pure-phase contrast `I−1 = −2 sin(χ) φ` for the
+    `exp(+iπλz|u|²)` propagator (previously the retrieved phase was inverted).
+- **`iterative_phase_retrieval`** — nonlinear iterative retrieval inverting the
+  **exact** Fresnel forward model by conjugate-gradient minimisation
+  (analytic adjoint gradient, finite-difference verified). Warm-started from
+  TIE-Hom. Single- or multi-distance (nonlinear holotomography, valid for
+  strong phase where linear CTF fails). Tikhonov (`reg_smooth`) and
+  edge-preserving total-variation (`reg_tv`) regularisation. Handles a 1-D
+  projection line exactly (used by the tomography pipeline).
+- **`suggest_holo_distances`** — builds a geometrically-spaced, gap-free
+  multi-distance series from the CTF-zero interleaving rules, parametrised by
+  the Fresnel-number span (`nf_short`/`nf_long`); verifies frequency coverage.
+
+### Added — ring artifact correction (`toupy.restoration`)
+
+- **`remove_rings_wavelet_fft`** — multi-scale wavelet stripe removal. Uses a
+  safe angular-mean (median-baseline) stripe subtraction on every band; the
+  subtracted stripe is constant across angle so real signal is never removed.
+- **`remove_rings_titarenko`** — single-scale median-profile correction.
+- **`remove_rings_stack`** — apply either method to a 3-D sinogram stack.
+
+### Added — total-variation reconstruction (`toupy.tomo`)
+
+- **`tv_reconstruction`** / **`chambolle_pock_tv`** — TV-regularised
+  reconstruction via the Chambolle–Pock primal–dual algorithm.
+
+### Added — examples (`tutorial/`)
+
+- `example_phase_retrieval_tv_ring.py` — phase retrieval (TIE-Hom + single- and
+  multi-distance CTF) + ring correction + FBP/TV reconstruction.
+- `example_iterative_phase_retrieval.py` — TIE-Hom vs nonlinear iterative
+  (single & multi-distance), with quantitative line profiles.
+- `example_iterative_phase_tomography.py` — full phase-contrast tomography
+  pipeline (per-angle retrieval → sinogram → FBP) plus a CTF frequency-coverage
+  diagnostic showing why multi-distance fills single-distance gaps.
+
+### Changed
+
+- Added GPU (CuPy) acceleration paths across the new modules, with automatic
+  CPU fallback when CuPy is not installed.

--- a/README.md
+++ b/README.md
@@ -58,11 +58,45 @@ Optional (for Jupyter notebook interactive plotting):
 * ipympl >= 0.9  (`pip install ipympl`)
 * jupyterlab >= 3.0
 
+Optional (for GPU acceleration of the phase-retrieval and reconstruction methods):
+
+* cupy  (e.g. `pip install cupy-cuda12x` — matched to your CUDA version)
+
 Get started
 -----------
 
 Get started quickly with the examples in the [templates](https://github.com/jcesardasilva/toupy/tree/master/templates) directory
 and the [tutorial notebooks](https://github.com/jcesardasilva/toupy/tree/master/tutorial).
+
+Phase retrieval, ring correction and TV reconstruction
+------------------------------------------------------
+
+Methods for propagation-based / holotomographic nanotomography.  All compute
+functions accept ``cuda=True`` for optional GPU acceleration via CuPy, falling
+back to CPU automatically when CuPy is not installed:
+
+* **Phase retrieval** (`toupy.restoration`)
+  * `tie_hom` — single-distance TIE-Hom (Paganin) retrieval for homogeneous objects.
+  * `ctf_retrieve` — CTF retrieval; single distance *or* multi-distance
+    (holotomographic) inversion via `delta_beta` and a list of distances.
+  * `iterative_phase_retrieval` — nonlinear retrieval using the exact Fresnel
+    forward model (single or multi-distance), with Tikhonov / total-variation
+    regularisation. Accurate in the multi-fringe / higher-δ/β regime where
+    TIE-Hom blurs.
+  * `suggest_holo_distances` — rule-based, gap-free multi-distance series for
+    holotomography (CTF-zero interleaving).
+* **Ring artifact correction** (`toupy.restoration`)
+  * `remove_rings_wavelet_fft`, `remove_rings_titarenko`, `remove_rings_stack`.
+* **Total-variation reconstruction** (`toupy.tomo`)
+  * `tv_reconstruction`, `chambolle_pock_tv` — TV-regularised FBP (Chambolle–Pock).
+
+Runnable examples in [`tutorial/`](tutorial/):
+
+* `example_phase_retrieval_tv_ring.py` — phase retrieval + ring correction + TV pipeline.
+* `example_iterative_phase_retrieval.py` — TIE-Hom vs nonlinear iterative (single & multi-distance).
+* `example_iterative_phase_tomography.py` — full phase-contrast tomography pipeline + CTF coverage diagnostic.
+
+See [`CHANGELOG.md`](CHANGELOG.md) for details.
 
 Call for Contributions
 ----------------------

--- a/toupy/restoration/__init__.py
+++ b/toupy/restoration/__init__.py
@@ -8,3 +8,4 @@ from .unwraptools import *
 from .ramptools import *
 from .derivativetools import *
 from .phase_retrieval import *
+from .ring_correction import *

--- a/toupy/restoration/__init__.py
+++ b/toupy/restoration/__init__.py
@@ -7,3 +7,4 @@ from .vorticestools import *
 from .unwraptools import *
 from .ramptools import *
 from .derivativetools import *
+from .phase_retrieval import *

--- a/toupy/restoration/phase_retrieval.py
+++ b/toupy/restoration/phase_retrieval.py
@@ -1,0 +1,699 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Phase retrieval for propagation-based X-ray imaging.
+
+Two methods are provided:
+
+TIE-Hom (Paganin et al., 2002)
+    Single-distance phase retrieval assuming a homogeneous object
+    (constant delta/beta ratio).  Extremely robust and the de-facto
+    standard for synchrotron nanotomography.
+
+    Reference:
+        Paganin, D., Mayo, S. C., Gureyev, T. E., Miller, P. R., &
+        Wilkins, S. W. (2002). Simultaneous phase and amplitude
+        extraction from a single defocused image of a homogeneous object.
+        Journal of Microscopy, 206(1), 33–40.
+        https://doi.org/10.1046/j.1365-2818.2002.01010.x
+
+CTF (Contrast Transfer Function)
+    Linear phase retrieval in the weak-phase / weak-absorption regime,
+    valid for a single propagation distance.  Handles the zeros of the
+    CTF via Tikhonov regularisation.
+
+    Reference:
+        Turner, L. D., Dhal, B. B., Hayes, J. P., Mancuso, A. P.,
+        Nugent, K. A., Paterson, D., ... & Peele, A. G. (2004).
+        X-ray phase imaging: Demonstration of extended conditions
+        for homogeneous objects. Optics Express, 12(13), 2960–2965.
+        https://doi.org/10.1364/OPEX.12.002960
+
+GPU notes
+---------
+Both functions accept ``cuda=True`` to run entirely on a CuPy GPU array.
+The input may be a CPU numpy array (it is uploaded automatically) and the
+output is always returned as a CPU numpy array.  When a stack (3-D array)
+is passed with ``cuda=True``, the full stack is batched on the GPU so that
+only one upload/download round-trip occurs regardless of the number of
+projections.
+"""
+
+import warnings
+import numpy as np
+from scipy.fft import fft2, ifft2, fftfreq
+
+# ---------------------------------------------------------------------------
+# Optional CuPy import — graceful degradation to CPU if unavailable
+# ---------------------------------------------------------------------------
+try:
+    import cupy as cp
+    CUDA_AVAILABLE = True
+except ImportError:
+    CUDA_AVAILABLE = False
+
+__all__ = ["tie_hom", "ctf_retrieve", "iterative_phase_retrieval",
+           "suggest_holo_distances"]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _get_xp(cuda):
+    """Return cupy if cuda is requested and available, else numpy."""
+    if cuda:
+        if not CUDA_AVAILABLE:
+            warnings.warn(
+                "CuPy not available — falling back to CPU phase retrieval.",
+                stacklevel=3,
+            )
+            return np
+        return cp
+    return np
+
+
+def _freq_grid(ny, nx, pixel_size, xp):
+    """Return (fy, fx) frequency grids in units of 1/pixel_size."""
+    fy = xp.fft.fftfreq(ny, d=pixel_size)
+    fx = xp.fft.fftfreq(nx, d=pixel_size)
+    return xp.meshgrid(fy, fx, indexing="ij")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def tie_hom(
+    intensity,
+    distance,
+    wavelength,
+    pixel_size,
+    delta_beta=1e3,
+    regularisation=1e-3,
+    cuda=False,
+):
+    """
+    Single-distance TIE-Hom (Paganin) phase retrieval.
+
+    Recovers the projected thickness (or phase) from a single defocused
+    intensity image assuming a homogeneous object with a fixed
+    delta / beta ratio.
+
+    The filter in frequency space is:
+
+    .. math::
+
+        \\hat{T}(\\mathbf{u}) =
+        \\frac{\\mathcal{F}\\{I / I_0\\}}
+             {1 + \\pi\\,\\lambda\\,z\\,(\\delta/\\beta)\\,|\\mathbf{u}|^2}
+
+    where the projected thickness is
+    :math:`T = -1/(\\mu) \\ln \\hat{T}`,
+    and the phase is :math:`\\phi = -T \\cdot (\\pi / (\\lambda z))`.
+
+    Parameters
+    ----------
+    intensity : ndarray, shape (M, N) or (K, M, N)
+        Measured intensity image(s).  A 3-D array is treated as a stack
+        of projections processed as a single GPU batch when ``cuda=True``.
+    distance : float
+        Sample-to-detector propagation distance [m].
+    wavelength : float
+        X-ray wavelength [m].
+    pixel_size : float
+        Effective detector pixel size at the sample plane [m].
+    delta_beta : float, optional
+        Ratio delta/beta of the complex refractive index decrement.
+        Typical values: 1e2–1e4 for biological soft tissue; 1e1–1e2 for
+        metals.  Default 1e3.
+    regularisation : float, optional
+        Tikhonov regularisation parameter alpha.  Prevents division by
+        zero when the denominator approaches unity.  Default 1e-3.
+    cuda : bool, optional
+        Run on GPU via CuPy.  Falls back to CPU with a warning if CuPy
+        is unavailable.  Default False.
+
+    Returns
+    -------
+    phase : ndarray, same shape as *intensity*
+        Retrieved phase image(s) [rad].  Always returned as a CPU array.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from toupy.restoration import tie_hom
+    >>> img = np.ones((256, 256))
+    >>> phase = tie_hom(img, distance=0.1, wavelength=1e-10,
+    ...                 pixel_size=1e-7, delta_beta=500)
+    """
+    xp = _get_xp(cuda)
+
+    intensity = np.asarray(intensity, dtype=float)
+    stack = intensity.ndim == 3
+    if not stack:
+        intensity = intensity[np.newaxis]
+
+    use_gpu = cuda and CUDA_AVAILABLE
+
+    # Upload entire stack in one round-trip when on GPU
+    arr = xp.asarray(intensity) if use_gpu else intensity
+
+    ny, nx = arr.shape[-2:]
+    fy, fx = _freq_grid(ny, nx, pixel_size, xp)
+    freq2 = fy**2 + fx**2
+
+    denom = 1.0 + np.pi * wavelength * distance * delta_beta * freq2
+    denom = xp.maximum(denom, regularisation)
+
+    # Batch FFT: fft2 on a 3-D array operates on the last two axes
+    I_mean = arr.mean(axis=(-2, -1), keepdims=True) + 1e-30
+    I_norm = arr / I_mean
+    filtered = xp.real(xp.fft.ifft2(xp.fft.fft2(I_norm) / denom))
+    phase = xp.log(xp.maximum(filtered, 1e-10)) * (-delta_beta / 2.0)
+
+    if use_gpu:
+        phase = cp.asnumpy(phase)
+    else:
+        phase = np.asarray(phase)
+
+    return phase[0] if not stack else phase
+
+
+def ctf_retrieve(
+    intensity,
+    distance,
+    wavelength,
+    pixel_size,
+    alpha=1e-3,
+    delta_beta=None,
+    cuda=False,
+):
+    """
+    CTF (Contrast Transfer Function) phase retrieval — single or multi-distance.
+
+    Linearised phase retrieval valid for a weakly-attenuating, weak-phase
+    object (``|φ| << 1 rad``).  Supports both single-distance inversion and
+    **multi-distance / holotomographic** inversion, and both pure-phase and
+    homogeneous (fixed δ/β) objects.
+
+    For the standard paraxial Fresnel propagator ``H_z = exp(+iπλz|u|²)`` the
+    linearised contrast of a homogeneous object is
+
+    .. math::
+
+        \\hat{H}_d(\\mathbf{u}) = -2\\,w_d(\\mathbf{u})\\,\\hat{\\phi}(\\mathbf{u}),
+        \\qquad
+        w_d = \\sin(\\chi_d) + \\varepsilon \\cos(\\chi_d),
+
+    with :math:`\\chi_d = \\pi\\lambda z_d |\\mathbf{u}|^2` and
+    :math:`\\varepsilon = \\beta/\\delta = 1/(\\delta/\\beta)` (``ε = 0`` for a
+    pure-phase object).  The least-squares Tikhonov inversion combining all
+    distances is
+
+    .. math::
+
+        \\hat{\\phi} = -\\frac{\\sum_d w_d \\hat{H}_d}
+                            {2\\left(\\sum_d w_d^2 + \\alpha\\right)} .
+
+    **Why multi-distance + δ/β recovers low frequencies.**  A single distance
+    transfers phase only in a band around the first CTF maximum
+    (:math:`\\chi \\approx \\pi/2`) and is blind at the CTF zeros and at DC
+    (:math:`\\sin\\chi \\to 0`).  Using several distances fills the zeros of
+    one with the maxima of another.  The absorption term
+    :math:`\\varepsilon\\cos(\\chi_d)` is non-zero at DC
+    (:math:`\\cos 0 = 1`), so a homogeneous object additionally recovers the
+    low frequencies — this is the basis of quantitative holotomography.
+
+    Parameters
+    ----------
+    intensity : ndarray
+        Measured intensity image(s), normalised so the vacuum level is 1.
+        Shapes accepted:
+
+        * ``(M, N)`` — one image, single distance.
+        * ``(K, M, N)`` with a **scalar** ``distance`` — a batch of *K*
+          independent projections, each retrieved separately.
+        * ``(D, M, N)`` with an **array** ``distance`` of length *D* — one
+          object imaged at *D* propagation distances, combined into a single
+          phase map (multi-distance / holotomography).
+    distance : float or sequence of float
+        Propagation distance(s) [m].  A sequence triggers the multi-distance
+        combination; its length must match ``intensity.shape[0]``.
+    wavelength : float
+        X-ray wavelength [m].
+    pixel_size : float
+        Effective detector pixel size [m].
+    alpha : float, optional
+        Tikhonov regularisation parameter.  Default 1e-3.
+    delta_beta : float or None, optional
+        Ratio δ/β of the complex refractive index.  When provided the
+        homogeneous (single-material) model is used, coupling absorption to
+        phase and enabling low-frequency / DC recovery.  ``None`` (default)
+        assumes a pure-phase object (``ε = 0``).
+    cuda : bool, optional
+        Run on GPU via CuPy.  Falls back to CPU with a warning if CuPy is
+        unavailable.  Default False.
+
+    Returns
+    -------
+    phase : ndarray
+        Retrieved phase [rad], always a CPU array.  Shape ``(M, N)`` for a
+        single image or a multi-distance set, or ``(K, M, N)`` for a batch
+        of independent projections.
+
+    Examples
+    --------
+    Single distance, pure phase:
+
+    >>> import numpy as np
+    >>> from toupy.restoration import ctf_retrieve
+    >>> img = np.ones((256, 256))
+    >>> phase = ctf_retrieve(img, distance=5e-5, wavelength=7.3e-11,
+    ...                      pixel_size=5e-8)
+
+    Multi-distance holotomographic retrieval of a homogeneous object:
+
+    >>> stack = np.ones((4, 256, 256))                     # 4 distances
+    >>> dists = [3e-5, 1.5e-4, 6e-4, 2.4e-3]
+    >>> phase = ctf_retrieve(stack, distance=dists, wavelength=7.3e-11,
+    ...                      pixel_size=5e-8, delta_beta=50.0)
+    """
+    xp = _get_xp(cuda)
+
+    distances = np.atleast_1d(np.asarray(distance, dtype=float))
+    multi = distances.size > 1
+
+    intensity = np.asarray(intensity, dtype=float)
+    if multi:
+        # One object, several distances -> combine into a single phase map.
+        if intensity.ndim != 3 or intensity.shape[0] != distances.size:
+            raise ValueError(
+                "Multi-distance CTF expects intensity of shape "
+                "(D, M, N) with D = len(distance) = {}, got {}.".format(
+                    distances.size, intensity.shape)
+            )
+        batch = False
+    else:
+        # Scalar distance: 2-D -> one image; 3-D -> batch of independent ones.
+        batch = intensity.ndim == 3
+        if not batch:
+            intensity = intensity[np.newaxis]
+
+    use_gpu = cuda and CUDA_AVAILABLE
+    arr = xp.asarray(intensity) if use_gpu else intensity
+
+    ny, nx = arr.shape[-2:]
+    fy, fx = _freq_grid(ny, nx, pixel_size, xp)
+    freq2 = fy**2 + fx**2
+    eps = 0.0 if delta_beta is None else 1.0 / float(delta_beta)
+
+    if multi:
+        # Combine distances: φ̂ = -Σ w_d Ĥ_d / (2 (Σ w_d² + α))
+        num = xp.zeros((ny, nx), dtype=complex)
+        den = xp.zeros((ny, nx))
+        for d in range(distances.size):
+            chi = np.pi * wavelength * float(distances[d]) * freq2
+            w = xp.sin(chi) + eps * xp.cos(chi)
+            num = num + w * xp.fft.fft2(arr[d] - 1.0)
+            den = den + w * w
+        phase = -xp.real(xp.fft.ifft2(num / (2.0 * (den + alpha))))
+    else:
+        # Single distance (optionally a batch of independent projections).
+        #
+        # Sign convention: for H_z = exp(+iπλz|u|²) the contrast is
+        #   I - 1 = -2 [sin(χ) + ε cos(χ)] φ
+        # so the inversion carries a leading MINUS sign to return +φ.
+        chi = np.pi * wavelength * float(distances[0]) * freq2
+        w = xp.sin(chi) + eps * xp.cos(chi)
+        H = xp.fft.fft2(arr - 1.0)
+        phase = -xp.real(xp.fft.ifft2(w * H / (2.0 * (w**2 + alpha))))
+
+    if use_gpu:
+        phase = cp.asnumpy(phase)
+    else:
+        phase = np.asarray(phase)
+
+    if multi:
+        return phase
+    return phase if batch else phase[0]
+
+
+# ---------------------------------------------------------------------------
+# Nonlinear iterative phase retrieval (full Fresnel forward model)
+# ---------------------------------------------------------------------------
+
+def iterative_phase_retrieval(
+    intensity,
+    distance,
+    wavelength,
+    pixel_size,
+    delta_beta,
+    init=None,
+    n_iter=200,
+    reg_smooth=1e-4,
+    reg_tv=0.0,
+    tv_eps=1e-3,
+    pad=2,
+    tol=1e-7,
+    cuda=False,
+    verbose=False,
+):
+    r"""
+    Nonlinear iterative phase retrieval using the exact Fresnel forward model.
+
+    Refines a phase map by minimising the mismatch between the measured
+    intensity and the intensity predicted by *propagating* a homogeneous-object
+    wavefield — i.e. it inverts the **full** near-field diffraction integral
+    instead of TIE-Hom's first-order (single-fringe) approximation.  This makes
+    it accurate in the **multi-fringe** regime (small Fresnel number) and at
+    higher δ/β, where the Paganin/TIE-Hom filter blurs and loses contrast.
+
+    The object is assumed homogeneous (single material), so absorption and
+    phase are coupled and the unknown is a single real field φ:
+
+    .. math::
+
+        \psi(\phi) = \exp\!\big[(-1/(\delta/\beta) + i)\,\phi\big].
+
+    For each propagation distance :math:`z_d` the model intensity is
+    :math:`I_d = |\mathcal{P}_{z_d}\,\psi(\phi)|^2`, where
+    :math:`\mathcal{P}_{z_d}` is the angular-spectrum (Fresnel) propagator.
+    The objective is the amplitude (Gaussian) data term plus a smoothness
+    (Tikhonov) prior
+
+    .. math::
+
+        J(\phi) = \tfrac12 \sum_d \big\|\,|\mathcal{P}_{z_d}\psi(\phi)|
+                  - \sqrt{I_d}\,\big\|^2
+                  + \tfrac{\mu}{2}\,\|\nabla\phi\|^2 ,
+
+    minimised by nonlinear conjugate gradient (Polak–Ribière) with an Armijo
+    backtracking line search.  The analytic gradient is obtained from the
+    adjoint (back-propagation) of the forward model.
+
+    Passing **several distances** turns this into *nonlinear holotomography*,
+    which — unlike the linear CTF — remains valid for strong phase
+    (:math:`|\phi| \gtrsim 1` rad) and recovers the low frequencies through the
+    absorption term.
+
+    Parameters
+    ----------
+    intensity : ndarray
+        Measured intensity, normalised to unit vacuum level.  Shape ``(M, N)``
+        for a single distance, or ``(D, M, N)`` with a length-*D* sequence
+        ``distance`` for multi-distance retrieval.
+    distance : float or sequence of float
+        Propagation distance(s) [m].
+    wavelength : float
+        X-ray wavelength [m].
+    pixel_size : float
+        Effective detector pixel size at the sample [m].
+    delta_beta : float
+        δ/β ratio of the (homogeneous) object.
+    init : ndarray or None, optional
+        Initial phase guess ``(M, N)``.  When ``None`` (default) the TIE-Hom
+        result at the first distance is used — the recommended warm start.
+    n_iter : int, optional
+        Maximum number of conjugate-gradient iterations.  Default 200.
+    reg_smooth : float, optional
+        Weight μ of the gradient-squared (Tikhonov) smoothness prior.  Set 0
+        to disable.  Default 1e-4.  Smooths uniformly (edges included).
+    reg_tv : float, optional
+        Weight of an (ε-smoothed) **total-variation** prior
+        :math:`\sum \sqrt{|\nabla\phi|^2 + \varepsilon^2}`.  Unlike the
+        quadratic prior, TV flattens residual ripples / Fresnel artefacts in
+        homogeneous regions while preserving sharp edges — recommended for
+        piecewise-constant samples and for cleaning single-distance results.
+        Set 0 to disable (default).  Typical range 1e-3–1e-2.
+    tv_eps : float, optional
+        Smoothing parameter ε of the TV norm (keeps it differentiable for the
+        conjugate-gradient solver).  Default 1e-3.
+    pad : int, optional
+        Zero/vacuum padding factor for the propagation FFTs, used to avoid
+        circular wrap-around of the Fresnel kernel.  Default 2.
+    tol : float, optional
+        Stop when the relative cost decrease falls below ``tol``.  Default 1e-7.
+    cuda : bool, optional
+        Run on GPU via CuPy (falls back to CPU with a warning).  Default False.
+    verbose : bool, optional
+        Print the cost every 25 iterations.  Default False.
+
+    Returns
+    -------
+    phase : ndarray, shape (M, N)
+        Retrieved phase [rad], always a CPU array.
+
+    Notes
+    -----
+    * **Phase wrapping.**  For a single distance the absolute phase is only
+      well determined up to wrapping; if the true phase greatly exceeds
+      :math:`\pi` the iteration may settle in a wrapped local minimum.  Use
+      several distances (and/or a good ``init``) for strong-phase objects.
+    * The object should sit inside the field of view with a vacuum margin so
+      that its propagation fringes are captured by the detector; otherwise the
+      boundary is under-constrained.
+
+    Examples
+    --------
+    >>> from toupy.restoration import iterative_phase_retrieval
+    >>> phase = iterative_phase_retrieval(I, distance=8e-4, wavelength=7.3e-11,
+    ...                                   pixel_size=5e-8, delta_beta=20.0)
+    """
+    xp = _get_xp(cuda)
+    use_gpu = cuda and CUDA_AVAILABLE
+
+    distances = np.atleast_1d(np.asarray(distance, dtype=float))
+    intensity = np.asarray(intensity, dtype=float)
+    if distances.size > 1:
+        if intensity.ndim != 3 or intensity.shape[0] != distances.size:
+            raise ValueError(
+                "Multi-distance retrieval expects intensity of shape "
+                "(D, M, N) with D = len(distance) = {}, got {}.".format(
+                    distances.size, intensity.shape))
+        stack = intensity
+    else:
+        stack = intensity[np.newaxis] if intensity.ndim == 2 else intensity
+
+    ny, nx = stack.shape[-2:]
+    pad = max(1, int(pad))
+    # Pad only axes with extent > 1 — a size-1 axis (e.g. a single tomographic
+    # projection line) then propagates as an exact 1-D Fresnel problem.
+    my = ny * pad if ny > 1 else 1
+    mx = nx * pad if nx > 1 else 1
+    oy, ox = (my - ny) // 2, (mx - nx) // 2
+
+    # Warm start: TIE-Hom at the first distance.
+    if init is None:
+        init = tie_hom(stack[0], float(distances[0]), wavelength, pixel_size,
+                       delta_beta=delta_beta, cuda=cuda)
+    phi = xp.asarray(np.asarray(init, dtype=float))
+
+    sqI = [xp.asarray(np.sqrt(stack[d])) for d in range(distances.size)]
+
+    # Padded Fresnel propagators, one per distance.
+    fy = xp.fft.fftfreq(my, d=pixel_size)
+    fx = xp.fft.fftfreq(mx, d=pixel_size)
+    FY, FX = xp.meshgrid(fy, fx, indexing="ij")
+    freq2 = FY**2 + FX**2
+    Hs = [xp.exp(1j * np.pi * wavelength * float(z) * freq2) for z in distances]
+    c = complex(-1.0 / float(delta_beta), 1.0)
+    c_conj = np.conj(c)
+
+    def _embed(a):
+        b = xp.zeros((my, mx), dtype=a.dtype)
+        b[oy:oy + ny, ox:ox + nx] = a
+        return b
+
+    def _crop(a):
+        return a[oy:oy + ny, ox:ox + nx]
+
+    def _cost_grad(phi):
+        psi = xp.exp(c * _embed(phi))
+        psi_f = xp.fft.fft2(psi)
+        J = 0.0
+        grad = xp.zeros((ny, nx))
+        for H, s in zip(Hs, sqI):
+            psz = xp.fft.ifft2(psi_f * H)            # propagate
+            amp = xp.abs(psz)
+            res = _crop(amp) - s                     # amplitude residual
+            J = J + 0.5 * float(xp.sum(res * res))
+            gz = _embed(res * _crop(psz) / (_crop(amp) + 1e-30))
+            gobj = xp.fft.ifft2(xp.fft.fft2(gz) * xp.conj(H))   # back-propagate
+            grad = grad + _crop(xp.real(c_conj * xp.conj(psi) * gobj))
+        if reg_smooth > 0:
+            dphi0 = phi - xp.roll(phi, 1, axis=0)
+            dphi1 = phi - xp.roll(phi, 1, axis=1)
+            J = J + 0.5 * reg_smooth * float(xp.sum(dphi0**2 + dphi1**2))
+            lap = (-4.0 * phi
+                   + xp.roll(phi, 1, 0) + xp.roll(phi, -1, 0)
+                   + xp.roll(phi, 1, 1) + xp.roll(phi, -1, 1))
+            grad = grad - reg_smooth * lap
+        if reg_tv > 0:
+            # Isotropic ε-smoothed TV: Σ sqrt(|∇φ|² + ε²); edge-preserving.
+            dx = xp.roll(phi, -1, axis=1) - phi
+            dy = xp.roll(phi, -1, axis=0) - phi
+            mag = xp.sqrt(dx**2 + dy**2 + tv_eps**2)
+            J = J + reg_tv * float(xp.sum(mag))
+            px, py = dx / mag, dy / mag
+            divp = (px - xp.roll(px, 1, axis=1)) + (py - xp.roll(py, 1, axis=0))
+            grad = grad - reg_tv * divp
+        return J, grad
+
+    # Nonlinear conjugate gradient (Polak–Ribière+) with Armijo backtracking.
+    J, g = _cost_grad(phi)
+    d = -g
+    t = 1.0
+    for it in range(int(n_iter)):
+        gd = float(xp.sum(g * d))
+        if gd >= 0:                       # not a descent direction → restart
+            d = -g
+            gd = float(xp.sum(g * d))
+        t = min(t * 2.0, 1e3)
+        Jn, gn = _cost_grad(phi + t * d)
+        n_ls = 0
+        while Jn > J + 1e-4 * t * gd and t > 1e-12 and n_ls < 60:
+            t *= 0.5
+            Jn, gn = _cost_grad(phi + t * d)
+            n_ls += 1
+        phi = phi + t * d
+        denom = float(xp.sum(g * g)) + 1e-30
+        beta = max(0.0, float(xp.sum(gn * (gn - g))) / denom)
+        d = -gn + beta * d
+        rel = (J - Jn) / (abs(J) + 1e-30)
+        g, J = gn, Jn
+        if verbose and (it % 25 == 0 or it == n_iter - 1):
+            print("  iter {:4d}   J = {:.6e}".format(it, J))
+        if 0.0 <= rel < tol:
+            break
+
+    return cp.asnumpy(phi) if use_gpu else np.asarray(phi)
+
+
+# ---------------------------------------------------------------------------
+# Helper: choose a gap-free multi-distance (holotomography) series
+# ---------------------------------------------------------------------------
+
+def suggest_holo_distances(
+    pixel_size,
+    wavelength,
+    n=4,
+    delta_beta=None,
+    nf_short=0.5,
+    nf_long=0.01,
+    f_lo=0.03,
+    warn_gap=0.02,
+    return_info=False,
+):
+    r"""
+    Suggest a geometrically-spaced set of propagation distances for
+    multi-distance (holotomographic) phase retrieval, and check it is gap-free.
+
+    The homogeneous phase transfer function at distance :math:`z` is
+    :math:`w_z(u) = \sin(\chi) + \varepsilon\cos(\chi)` with
+    :math:`\chi = \pi\lambda z u^2` and :math:`\varepsilon = 1/(\delta/\beta)`.
+    A single distance loses information at its CTF zeros
+    :math:`u_n = \sqrt{n/(\lambda z)}`.  Several distances fill those gaps when
+    their zeros **interleave**, which happens for a geometric spacing of *z*.
+
+    The series is built directly from the two Fresnel-number end points:
+
+    * the **shortest** distance has :math:`N_F = N_{F,\mathrm{short}}`
+      (:math:`N_F = \mathrm{pixel}^2/(\lambda z)`).  Keep
+      ``nf_short ≳ 0.25`` so its first zero sits at/beyond Nyquist — a smooth,
+      zero-free backbone that ensures no frequency is entirely lost;
+    * the **longest** distance has :math:`N_F = N_{F,\mathrm{long}}`.  Smaller
+      ``nf_long`` (longer z) improves the low-frequency / quantitative DC
+      transfer; it is bounded in practice by coherence, detector blur, geometry
+      and the Fresnel sampling limit :math:`z < N\,\mathrm{pixel}^2/\lambda`;
+    * the intermediate distances are spaced **geometrically**
+      :math:`z_d = z_0\,R^{\,d}`, :math:`R=(z_{n-1}/z_0)^{1/(n-1)}`, which
+      makes the CTF zeros interleave evenly.
+
+    The worst-case combined transfer :math:`\sqrt{\langle w_z^2\rangle}` over
+    ``f_lo·u_Nyq ≤ u ≤ u_Nyq`` is evaluated; a warning is issued if it falls
+    below ``warn_gap`` (a residual gap).
+
+    Parameters
+    ----------
+    pixel_size : float
+        Effective detector pixel size at the sample [m].
+    wavelength : float
+        X-ray wavelength [m].
+    n : int, optional
+        Number of distances.  Default 4.
+    delta_beta : float or None, optional
+        δ/β of the object.  Includes the absorption term in the transfer
+        function (improves low-frequency coverage).  ``None`` → pure phase.
+    nf_short : float, optional
+        Fresnel number of the **shortest** distance.  Default 0.5 (zero-free,
+        with margin above the 0.25 limit).
+    nf_long : float, optional
+        Fresnel number of the **longest** distance.  Default 0.01.
+    f_lo : float, optional
+        Lowest frequency (fraction of Nyquist) at which coverage is required;
+        below it transfer is intrinsically weak (→ ε at DC).  Default 0.03.
+    warn_gap : float, optional
+        Warn if the worst-case combined transfer drops below this.  Default
+        0.02.
+    return_info : bool, optional
+        If True, also return a diagnostics dict.  Default False.
+
+    Returns
+    -------
+    distances : ndarray, shape (n,)
+        Suggested propagation distances [m], ascending.
+    info : dict, optional
+        Present when ``return_info=True``: ``ratio`` *R*, ``min_coverage``
+        (worst combined transfer; larger is better, ~0 means a gap), ``NF``
+        (per-distance Fresnel numbers).
+
+    Examples
+    --------
+    >>> from toupy.restoration import suggest_holo_distances, iterative_phase_retrieval
+    >>> z = suggest_holo_distances(50e-9, 7.3e-11, n=4, delta_beta=20)
+    >>> # ... acquire/simulate the intensity stack at these distances ...
+    >>> # phase = iterative_phase_retrieval(stack, z, 7.3e-11, 5e-8, delta_beta=20)
+    """
+    n = int(n)
+    if nf_long >= nf_short:
+        raise ValueError("nf_long ({}) must be < nf_short ({}) — the longest "
+                         "distance has the smaller Fresnel number."
+                         .format(nf_long, nf_short))
+    eps = 0.0 if delta_beta is None else 1.0 / float(delta_beta)
+    u_nyq = 1.0 / (2.0 * pixel_size)
+    z_short = pixel_size**2 / (wavelength * nf_short)
+    z_long = pixel_size**2 / (wavelength * nf_long)
+
+    if n <= 1:
+        distances = np.array([z_short])
+        ratio = float("nan")
+    else:
+        ratio = (z_long / z_short) ** (1.0 / (n - 1))
+        distances = z_short * ratio ** np.arange(n)
+    distances = np.asarray(distances, dtype=float)
+
+    # Worst-case combined transfer over the requested band.
+    u = np.linspace(f_lo * u_nyq, u_nyq, 1400)
+    acc = np.zeros_like(u)
+    for z in distances:
+        chi = np.pi * wavelength * z * u**2
+        acc = acc + (np.sin(chi) + eps * np.cos(chi)) ** 2
+    min_cov = float(np.sqrt(acc / n).min())
+    if min_cov < warn_gap:
+        warnings.warn(
+            "Suggested distances leave a residual frequency gap "
+            "(min combined transfer {:.3f} < {:.3f}). Consider more distances "
+            "or a wider nf_short/nf_long span.".format(min_cov, warn_gap),
+            stacklevel=2,
+        )
+
+    if return_info:
+        info = {
+            "ratio": ratio,
+            "min_coverage": min_cov,
+            "NF": [pixel_size**2 / (wavelength * z) for z in distances],
+        }
+        return distances, info
+    return distances

--- a/toupy/restoration/ring_correction.py
+++ b/toupy/restoration/ring_correction.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Ring artifact correction for tomographic sinograms.
+
+Two methods are provided:
+
+**Wavelet-FFT method (Münch et al., 2009)**
+    Decomposes the sinogram with a Haar wavelet along the detector-pixel
+    axis, then — for every sub-band including the final approximation —
+    estimates the ring contribution from the per-pixel angular mean and
+    removes it by Gaussian background subtraction.  The result is
+    equivalent to the multi-scale stripe filter described by Münch et al.
+    but is implemented without the FFT-based DC suppression that would
+    also remove real mean-projection signal.
+
+    Reference:
+        Münch, B., Trtik, P., Marone, F., & Stampanoni, M. (2009).
+        Stripe and ring artifact removal with combined wavelet — Fourier
+        filtering. Optics Express, 17(10), 8567–8591.
+        https://doi.org/10.1364/OE.17.008567
+
+**Titarenko method (Titarenko et al., 2010)**
+    Lightweight correction based on angular block-mean statistics.  Works
+    well for narrow, isolated rings.
+
+    Reference:
+        Titarenko, V., Titarenko, S., Withers, P. J., De Carlo, F., &
+        Xiao, X. (2010).  Applied Physics Letters, 97(7), 073905.
+        https://doi.org/10.1063/1.3480961
+
+GPU notes
+---------
+Both functions accept ``cuda=True``.  The Haar decomposition and
+reconstruction are fully vectorised over detector columns and map
+directly onto CuPy array operations.
+"""
+
+import warnings
+import numpy as np
+from scipy.ndimage import gaussian_filter1d, median_filter
+
+# ---------------------------------------------------------------------------
+# Optional CuPy import — graceful CPU fallback
+# ---------------------------------------------------------------------------
+try:
+    import cupy as cp
+    CUDA_AVAILABLE = True
+except ImportError:
+    CUDA_AVAILABLE = False
+
+__all__ = ["remove_rings_wavelet_fft", "remove_rings_titarenko",
+           "remove_rings_stack"]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _get_xp(cuda):
+    if cuda:
+        if not CUDA_AVAILABLE:
+            warnings.warn(
+                "CuPy not available — falling back to CPU ring correction.",
+                stacklevel=3,
+            )
+            return np
+        return cp
+    return np
+
+
+def _haar_dec(cH, xp):
+    """Vectorised one-level Haar decomposition along axis 0."""
+    a = (cH[0::2, :] + cH[1::2, :]) * 0.5
+    d = (cH[0::2, :] - cH[1::2, :]) * 0.5
+    return a, d
+
+
+def _haar_rec(a, d, xp):
+    """Vectorised one-level Haar reconstruction along axis 0."""
+    rec = xp.empty((a.shape[0] * 2, a.shape[1]), dtype=a.dtype)
+    rec[0::2, :] = a + d
+    rec[1::2, :] = a - d
+    return rec
+
+
+def _correct_band(band, win_pix, xp):
+    """Subtract ring stripes from a wavelet sub-band (angular-mean method).
+
+    Ring artifacts are, by definition, **constant across all projection
+    angles** — an additive offset at a fixed detector pixel.  For each
+    band-pixel we therefore estimate the stripe as
+
+        stripe[p] = mean_over_angles(band[p, :])
+                    - smooth_baseline(mean_over_angles(band)[p])
+
+    where the smooth baseline (a wide median filter along the *pixel*
+    axis) follows the real object profile but ignores the narrow ring
+    spikes.  Subtracting ``stripe`` from every angle removes the ring.
+
+    This operation is *safe*: because the subtracted quantity is constant
+    along the angle axis, it can never remove or distort the real,
+    angularly-varying projection signal — unlike Fourier DC suppression,
+    which leaks into low (but non-zero) angular frequencies.
+
+    Parameters
+    ----------
+    band : ndarray, shape (n_pix_band, n_angles)
+    win_pix : int
+        Median-filter window (in band-pixel units) used to estimate the
+        smooth object baseline.  Must be >> ring width but < object scale.
+    xp : numpy or cupy module
+    """
+    # Per-pixel angular mean: real smooth profile + sharp ring spikes
+    dc = band.mean(axis=1)                          # (n_pix_band,)
+    dc_cpu = cp.asnumpy(dc) if xp is not np else np.asarray(dc)
+
+    # Robust smooth baseline (median ignores the narrow ring spikes)
+    win = max(3, int(win_pix))
+    if win % 2 == 0:
+        win += 1
+    base = median_filter(dc_cpu, size=win)
+
+    stripe = dc_cpu - base                          # the ring component
+    stripe = xp.asarray(stripe) if xp is not np else stripe
+    return band - stripe[:, None]
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def remove_rings_wavelet_fft(
+    sinogram,
+    level=3,
+    sigma=3,
+    wname="haar",
+    cuda=False,
+):
+    """
+    Remove ring artifacts using multi-scale wavelet stripe subtraction.
+
+    The sinogram is decomposed with a Haar wavelet along the
+    detector-pixel axis (axis 0) for *level* levels.  At each scale —
+    including the final approximation band — a per-pixel angular mean is
+    computed and a Gaussian-smoothed background is subtracted to isolate
+    the ring contribution.  The cleaned bands are then reconstructed.
+
+    Parameters
+    ----------
+    sinogram : ndarray, shape (n_pixels, n_angles)
+        Input sinogram.  axis 0 = detector pixels; axis 1 = angles.
+    level : int, optional
+        Number of Haar decomposition levels.  Default 3.
+    sigma : float, optional
+        Expected maximum ring width in **original detector-pixel** units.
+        The Gaussian background estimation uses a smoothing sigma of
+        ``max(nrow / 10, sigma * 10)`` pixels (in the original sinogram),
+        scaled proportionally for each wavelet band so that the
+        separation of ring spikes from real-signal background is
+        consistent across all scales.  Default 3.
+    wname : str, optional
+        Wavelet family.  Only ``'haar'`` is supported.  Default ``'haar'``.
+    cuda : bool, optional
+        Use GPU via CuPy.  Default False.
+
+    Returns
+    -------
+    corrected : ndarray, shape (n_pixels, n_angles)
+        Ring-corrected sinogram (CPU numpy array).
+
+    Notes
+    -----
+    The method suppresses **additive** stripes (constant angular offset
+    at specific detector pixels).  Multiplicative non-uniformity should
+    be removed by flat-field normalisation first.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from toupy.restoration import remove_rings_wavelet_fft
+    >>> sino = np.random.rand(363, 180)
+    >>> sino_clean = remove_rings_wavelet_fft(sino, level=3, sigma=3)
+    """
+    xp = _get_xp(cuda)
+    sino_cpu = np.asarray(sinogram, dtype=float)
+    nrow, ncol = sino_cpu.shape
+    use_gpu = cuda and CUDA_AVAILABLE
+    arr = xp.asarray(sino_cpu) if use_gpu else sino_cpu.copy()
+
+    # Pad to the next power-of-2 along the pixel axis for clean decomposition
+    target = int(2 ** np.ceil(np.log2(max(nrow, 2))))
+    cH = xp.pad(arr, ((0, target - nrow), (0, 0)), mode="reflect")
+
+    details = []
+    band_sizes = []
+    for _ in range(level):
+        if cH.shape[0] < 4:
+            details.append(None)
+            band_sizes.append(None)
+            continue
+        a, d = _haar_dec(cH, xp)
+        details.append(d)
+        band_sizes.append(d.shape[0])
+        cH = a
+
+    # ------------------------------------------------------------------
+    # Ring correction: angular-mean stripe subtraction on EVERY band.
+    #
+    # Because the subtracted stripe is constant along the angle axis, the
+    # operation is safe on all bands — including the final approximation,
+    # which holds the smooth real-signal background.  (The old FFT-DC
+    # approach leaked into low angular frequencies and destroyed real
+    # signal; it has been replaced.)
+    #
+    # The median window is set once in original-pixel units and scaled
+    # down for each (decimated) wavelet band so the physical separation
+    # of ring spikes from object features is consistent across scales.
+    # ------------------------------------------------------------------
+    win_full = max(int(target / 10), int(sigma) * 10)   # original-pixel units
+
+    # Correct the final approximation band (size = target / 2**level)
+    win_approx = max(3, int(win_full * cH.shape[0] / target))
+    cH = _correct_band(cH, win_approx, xp)
+
+    # Correct each detail band with a band-scaled window
+    damped = []
+    for d, nb in zip(details, band_sizes):
+        if d is None:
+            damped.append(None)
+            continue
+        win_band = max(3, int(win_full * nb / target))
+        damped.append(_correct_band(d, win_band, xp))
+
+    # Reconstruct
+    result = cH
+    for d in reversed(damped):
+        if d is None:
+            continue
+        result = _haar_rec(result, d, xp)
+
+    out = result[:nrow, :]
+    return cp.asnumpy(out) if use_gpu else np.asarray(out)
+
+
+def remove_rings_titarenko(sinogram, size=31, cuda=False):
+    """
+    Remove ring artifacts using median-filter background subtraction.
+
+    Lightweight single-scale method: compute the per-pixel angular mean,
+    median-filter it to estimate the smooth background, and subtract the
+    residual (ring) from every angle.  Equivalent to the wavelet method
+    with level=0 (no decomposition).
+
+    Parameters
+    ----------
+    sinogram : ndarray, shape (n_pixels, n_angles)
+    size : int, optional
+        Median filter window size in pixels.  Should be >> ring width
+        but << real-signal variation scale.  Typical range: 21–51.
+        Default 31.
+    cuda : bool, optional
+        Use GPU.  Default False.
+
+    Returns
+    -------
+    corrected : ndarray, shape (n_pixels, n_angles)
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from toupy.restoration import remove_rings_titarenko
+    >>> sino = np.random.rand(363, 180)
+    >>> sino_clean = remove_rings_titarenko(sino, size=31)
+    """
+    xp = _get_xp(cuda)
+    sino_cpu = np.asarray(sinogram, dtype=float)
+    nrow, ncol = sino_cpu.shape
+    use_gpu = cuda and CUDA_AVAILABLE
+    arr = xp.asarray(sino_cpu) if use_gpu else sino_cpu.copy()
+
+    # Per-pixel angular mean
+    dc = arr.mean(axis=1)                     # (nrow,)
+
+    # Median-filter to estimate smooth background
+    smooth = median_filter(np.asarray(dc), size=max(3, int(size)))
+    if use_gpu:
+        smooth = xp.asarray(smooth)
+
+    # Subtract ring residual from every angle
+    ring = dc - smooth
+    out = arr - ring[:, None]
+    return cp.asnumpy(out) if use_gpu else np.asarray(out)
+
+
+def remove_rings_stack(stack, method="wavelet_fft", cuda=False, **kwargs):
+    """
+    Apply ring correction to a full 3-D sinogram stack.
+
+    Parameters
+    ----------
+    stack : ndarray, shape (n_pixels, n_slices, n_angles)
+    method : {'wavelet_fft', 'titarenko'}
+    cuda : bool, optional
+    **kwargs : forwarded to the chosen correction function.
+
+    Returns
+    -------
+    corrected : ndarray, same shape as *stack*
+    """
+    if method == "wavelet_fft":
+        fn = remove_rings_wavelet_fft
+    elif method == "titarenko":
+        fn = remove_rings_titarenko
+    else:
+        raise ValueError("Unknown method '{}'".format(method))
+
+    out = np.empty_like(stack)
+    n_slices = stack.shape[1]
+    for s in range(n_slices):
+        out[:, s, :] = fn(stack[:, s, :], cuda=cuda, **kwargs)
+    return out

--- a/toupy/tomo/__init__.py
+++ b/toupy/tomo/__init__.py
@@ -8,3 +8,4 @@ from .tomorecons import *
 from .geometry import *
 from .fdk import *
 from .cone_projector import *
+from .tv_recons import *

--- a/toupy/tomo/tv_recons.py
+++ b/toupy/tomo/tv_recons.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Total-Variation (TV) regularised tomographic reconstruction.
+
+Implements the Chambolle-Pock primal-dual algorithm (CP) to solve:
+
+    min_{x >= 0}  (1/2) ||A x - b||^2  +  lambda * TV(x)
+
+where A is the Radon forward operator, b is the (possibly noisy)
+sinogram, and TV is the isotropic discrete total-variation.
+
+The algorithm is an exact first-order method and handles the non-smooth
+TV term via proximal splitting.  It is well-suited to ptychographic
+tomography, where the phase sinogram is noisy or has limited angular
+sampling.
+
+Reference:
+    Chambolle, A., & Pock, T. (2011). A first-order primal-dual
+    algorithm for convex problems with applications to imaging. Journal
+    of Mathematical Imaging and Vision, 40(1), 120–145.
+    https://doi.org/10.1007/s10107-010-0436-y
+
+    Sidky, E. Y., & Pan, X. (2008). Image reconstruction in circular
+    cone-beam computed tomography by constrained, total-variation
+    minimization. Physics in Medicine & Biology, 53(17), 4777.
+    https://doi.org/10.1088/0031-9155/53/17/014
+
+GPU notes
+---------
+Both public functions accept ``cuda=True``.  In GPU mode all primal and
+dual variables reside on the device as CuPy float32 arrays throughout
+the iteration; only the final reconstruction is transferred back to the
+host.  The Radon forward and backward operators reuse the CUDA kernels
+compiled in :mod:`toupy.tomo.iradon`; no additional compilation is
+required.
+
+The step-size estimate is also computed entirely on the GPU via a
+five-step power iteration, so the first call is slightly slower than
+subsequent calls (kernel reuse).
+"""
+
+import warnings
+import numpy as np
+from skimage.transform import radon, iradon
+
+# ---------------------------------------------------------------------------
+# Optional CuPy / CUDA kernel imports — graceful CPU fallback
+# ---------------------------------------------------------------------------
+try:
+    import cupy as cp
+    from .iradon import CUDA_AVAILABLE, _fbp_kernel, _radon_kernel
+except ImportError:
+    CUDA_AVAILABLE = False
+
+__all__ = ["tv_reconstruction", "chambolle_pock_tv"]
+
+
+# ---------------------------------------------------------------------------
+# Array-library-agnostic finite-difference operators
+# Implemented with slicing (not np.roll) so the same code runs on both
+# NumPy and CuPy arrays.
+# ---------------------------------------------------------------------------
+
+def _get_xp(arr):
+    """Return cupy if arr is a CuPy array, else numpy."""
+    if CUDA_AVAILABLE:
+        return cp.get_array_module(arr)
+    return np
+
+
+def _grad2d(u):
+    """Forward finite-difference gradient (dy, dx), Neumann BC."""
+    xp = _get_xp(u)
+    gy = xp.empty_like(u)
+    gx = xp.empty_like(u)
+    gy[:-1, :] = u[1:, :] - u[:-1, :]
+    gy[-1, :]  = 0.0
+    gx[:, :-1] = u[:, 1:] - u[:, :-1]
+    gx[:, -1]  = 0.0
+    return gy, gx
+
+
+def _div2d(gy, gx):
+    """Negative divergence (adjoint of _grad2d), Neumann BC."""
+    xp = _get_xp(gy)
+    dy = xp.empty_like(gy)
+    dy[0, :]    =  gy[0, :]
+    dy[1:-1, :] =  gy[1:-1, :] - gy[:-2, :]
+    dy[-1, :]   = -gy[-2, :]
+    dx = xp.empty_like(gx)
+    dx[:, 0]    =  gx[:, 0]
+    dx[:, 1:-1] =  gx[:, 1:-1] - gx[:, :-2]
+    dx[:, -1]   = -gx[:, -2]
+    return dy + dx
+
+
+# ---------------------------------------------------------------------------
+# TV proximal operators (array-library agnostic)
+# ---------------------------------------------------------------------------
+
+def _prox_tv_dual(py, px, lam):
+    """Project TV dual onto the isotropic l-inf ball of radius lam.
+
+    prox_{sigma * (lam*||·||_{2,1})*}(z) = z / max(1, |z| / lam)
+    The step-size sigma is already folded into z before calling.
+    """
+    xp    = _get_xp(py)
+    norm  = xp.sqrt(py**2 + px**2)
+    scale = xp.maximum(1.0, norm / lam)
+    return py / scale, px / scale
+
+
+def _prox_l2_data_dual(z, b, sigma):
+    """Proximal op of the conjugate of (1/2)||· - b||^2, step sigma.
+
+    Moreau identity:  prox_{sigma * f*}(z) = (z - sigma*b) / (1 + sigma)
+    """
+    return (z - sigma * b) / (1.0 + sigma)
+
+
+# ---------------------------------------------------------------------------
+# CPU Radon / back-projection wrappers (skimage)
+# ---------------------------------------------------------------------------
+
+def _forward_cpu(x, theta):
+    return radon(x, theta=theta, circle=False)
+
+
+def _backward_cpu(sino, theta, n):
+    return iradon(sino, theta=theta, filter_name=None, output_size=n, circle=False)
+
+
+# ---------------------------------------------------------------------------
+# GPU Radon / back-projection wrappers (custom CUDA kernels from iradon.py)
+# ---------------------------------------------------------------------------
+# Convention used here matches skimage circle=False:
+#   nbins = ceil(sqrt(2) * n)
+# All GPU arrays are float32.
+# ---------------------------------------------------------------------------
+
+def _make_trig_gpu(theta_deg):
+    """Precompute float32 cos/sin tables on the GPU."""
+    th = np.deg2rad(np.asarray(theta_deg, dtype=np.float64)).astype(np.float32)
+    return cp.asarray(np.cos(th)), cp.asarray(np.sin(th))
+
+
+def _forward_gpu(x_gpu, cos_th, sin_th, nbins, nsteps):
+    """GPU Radon forward projection.
+
+    Parameters
+    ----------
+    x_gpu : cupy.ndarray, shape (N, N), float32
+    cos_th, sin_th : cupy.ndarray, shape (nangles,), float32
+    nbins : int   — number of detector bins (= ceil(sqrt(2)*N) for circle=False)
+    nsteps : int  — integration steps along ray
+
+    Returns
+    -------
+    sino_gpu : cupy.ndarray, shape (nbins, nangles), float32
+    """
+    N       = x_gpu.shape[0]
+    nangles = cos_th.shape[0]
+    sino_flat = cp.zeros(nbins * nangles, dtype=cp.float32)
+
+    block = (16, 16, 1)
+    grid  = (int(np.ceil(nbins   / 16)),
+             int(np.ceil(nangles / 16)), 1)
+    _radon_kernel(
+        grid, block,
+        (x_gpu.ravel(), sino_flat, cos_th, sin_th,
+         np.int32(N), np.int32(nbins), np.int32(nangles), np.int32(nsteps)),
+    )
+    cp.cuda.stream.get_current_stream().synchronize()
+    # Kernel stores (nangles * nbins) in angle-major order → transpose to (nbins, nangles)
+    return sino_flat.reshape(nangles, nbins).T
+
+
+def _backward_gpu(sino_gpu, n, cos_th, sin_th):
+    """GPU unfiltered back-projection (adjoint of _forward_gpu).
+
+    Parameters
+    ----------
+    sino_gpu : cupy.ndarray, shape (nbins, nangles), float32
+    n : int   — output image side length
+    cos_th, sin_th : cupy.ndarray, shape (nangles,), float32
+
+    Returns
+    -------
+    img_gpu : cupy.ndarray, shape (n, n), float32
+    """
+    nbins, nangles = sino_gpu.shape
+    mid_index = nbins // 2
+    img_flat  = cp.zeros(n * n, dtype=cp.float32)
+
+    # Kernel expects sinogram in (nangles * nbins,) angle-major column-major order
+    sino_cm = cp.ascontiguousarray(sino_gpu.T).ravel()
+
+    block = (16, 16, 1)
+    grid  = (int(np.ceil(n / 16)), int(np.ceil(n / 16)), 1)
+    _fbp_kernel(
+        grid, block,
+        (sino_cm, cos_th, sin_th, img_flat,
+         np.int32(n), np.int32(nbins), np.int32(nangles), np.int32(mid_index)),
+    )
+    cp.cuda.stream.get_current_stream().synchronize()
+    return img_flat.reshape(n, n)
+
+
+# ---------------------------------------------------------------------------
+# Step-size estimation via power iteration
+# ---------------------------------------------------------------------------
+
+def _estimate_norm_K2_cpu(n, theta, n_iter=5):
+    """Estimate ||K||^2 = ||A||^2 + 8 on CPU via power iteration."""
+    rng = np.random.default_rng(0)
+    v = rng.standard_normal((n, n))
+    for _ in range(n_iter):
+        Av   = _forward_cpu(v, theta)
+        ATAv = _backward_cpu(Av, theta, n)
+        norm2 = np.sqrt(np.sum(ATAv**2) / (np.sum(v**2) + 1e-30))
+        v = ATAv / (np.linalg.norm(ATAv) + 1e-30)
+    return float(norm2) + 8.0
+
+
+def _estimate_norm_K2_gpu(n, cos_th, sin_th, nbins, nsteps, n_iter=5):
+    """Estimate ||K||^2 on GPU via power iteration (all ops stay on device)."""
+    v = cp.random.default_rng(0).standard_normal((n, n)).astype(cp.float32)
+    for _ in range(n_iter):
+        Av   = _forward_gpu(v, cos_th, sin_th, nbins, nsteps)
+        ATAv = _backward_gpu(Av, n, cos_th, sin_th)
+        norm2 = float(cp.sqrt(cp.sum(ATAv**2) / (cp.sum(v**2) + 1e-30)))
+        ATAv_norm = float(cp.linalg.norm(ATAv))
+        v = ATAv / (ATAv_norm + 1e-30)
+    return norm2 + 8.0
+
+
+# ---------------------------------------------------------------------------
+# Core Chambolle-Pock solver
+# ---------------------------------------------------------------------------
+
+def chambolle_pock_tv(
+    sinogram,
+    theta,
+    lam=1e-2,
+    n_iter=100,
+    output_size=None,
+    cuda=False,
+    verbose=False,
+):
+    """
+    Chambolle-Pock TV-regularised reconstruction.
+
+    Solves the primal-dual saddle-point problem:
+
+    .. math::
+
+        \\min_{x \\ge 0}\\; \\max_{p,q}\\;
+        \\langle K x,\\, (p, q) \\rangle
+        - G^*(p, q) + F(x)
+
+    where :math:`K = (A,\\, \\nabla)` stacks the Radon operator and the
+    gradient, :math:`G^*` is the convex conjugate of the data and TV
+    terms, and :math:`F` is the non-negativity indicator.
+
+    Parameters
+    ----------
+    sinogram : ndarray, shape (n_pixels, n_angles)
+        Measured sinogram with axes (detector pixel, angle).
+    theta : array_like, shape (n_angles,)
+        Projection angles [degrees].
+    lam : float, optional
+        TV regularisation weight.  Default 1e-2.
+    n_iter : int, optional
+        Number of Chambolle-Pock iterations.  Default 100.
+    output_size : int or None, optional
+        Side length of the square reconstruction grid.  When ``None``
+        the value is inferred from the sinogram as
+        ``round(n_pixels / sqrt(2))``, matching
+        ``skimage.transform.radon`` with ``circle=False``.
+    cuda : bool, optional
+        Run on GPU via CuPy.  All primal/dual variables reside on the
+        device throughout the iteration; only the final image is
+        transferred back.  Falls back to CPU with a warning when CuPy
+        is unavailable.  Default False.
+    verbose : bool, optional
+        Print cost every 10 iterations.  Default False.
+
+    Returns
+    -------
+    x : ndarray, shape (output_size, output_size)
+        Reconstructed image.  Always returned as a CPU numpy array.
+
+    See Also
+    --------
+    tv_reconstruction : High-level wrapper with FBP warm-start.
+    """
+    if cuda and not CUDA_AVAILABLE:
+        warnings.warn(
+            "CuPy not available — falling back to CPU TV reconstruction.",
+            stacklevel=2,
+        )
+        cuda = False
+
+    theta    = np.asarray(theta, dtype=float)
+    sinogram = np.asarray(sinogram, dtype=float)
+    n_pix, n_ang = sinogram.shape
+
+    if output_size is None:
+        n = int(np.round(n_pix / np.sqrt(2)))
+    else:
+        n = int(output_size)
+
+    # ------------------------------------------------------------------
+    # GPU path
+    # ------------------------------------------------------------------
+    if cuda:
+        nbins  = int(np.ceil(np.sqrt(2) * n))
+        nsteps = int(np.ceil(n * np.sqrt(2)))
+        cos_th, sin_th = _make_trig_gpu(theta)
+
+        norm_K2 = _estimate_norm_K2_gpu(n, cos_th, sin_th, nbins, nsteps)
+        tau     = np.float32(0.9 / np.sqrt(norm_K2))
+        sigma   = np.float32(0.9 / np.sqrt(norm_K2))
+
+        # Allocate all variables on GPU as float32
+        x     = cp.zeros((n, n),        dtype=cp.float32)
+        x_bar = cp.zeros((n, n),        dtype=cp.float32)
+        py    = cp.zeros((n, n),        dtype=cp.float32)
+        px    = cp.zeros((n, n),        dtype=cp.float32)
+
+        # Sinogram dual variable — shape matches forward projection output
+        q     = cp.zeros((nbins, n_ang), dtype=cp.float32)
+        b_gpu = cp.asarray(sinogram,     dtype=cp.float32)
+
+        # The measured sinogram may have a different detector size than nbins
+        # (e.g. generated with skimage circle=False giving ceil(sqrt(2)*orig_n)).
+        # Resize q and b to match if necessary.
+        if b_gpu.shape[0] != nbins:
+            # Interpolate sinogram to match GPU forward operator output size
+            from cupyx.scipy.ndimage import zoom as cp_zoom
+            scale = nbins / b_gpu.shape[0]
+            b_gpu = cp_zoom(b_gpu, (scale, 1.0), order=1)
+
+        for it in range(n_iter):
+            Ax_bar = _forward_gpu(x_bar, cos_th, sin_th, nbins, nsteps)
+            q      = _prox_l2_data_dual(q + sigma * Ax_bar, b_gpu, sigma)
+
+            gy, gx = _grad2d(x_bar)
+            py, px = _prox_tv_dual(py + sigma * gy, px + sigma * gx, lam)
+
+            AT_q  = _backward_gpu(q, n, cos_th, sin_th)
+            div_p = _div2d(py, px)
+            x_new = cp.maximum(x - tau * (AT_q + div_p), 0.0)
+
+            x_bar = 2.0 * x_new - x
+            x     = x_new
+
+            if verbose and (it % 10 == 0):
+                gy_x, gx_x = _grad2d(x)
+                cost = (0.5 * float(cp.sum((_forward_gpu(
+                            x, cos_th, sin_th, nbins, nsteps) - b_gpu)**2))
+                        + lam * float(cp.sum(cp.sqrt(gy_x**2 + gx_x**2))))
+                print("  iter {:4d}  cost = {:.6e}".format(it, cost))
+
+        return cp.asnumpy(x)
+
+    # ------------------------------------------------------------------
+    # CPU path
+    # ------------------------------------------------------------------
+    rng = np.random.default_rng(0)
+    v = rng.standard_normal((n, n))
+    for _ in range(5):
+        Av   = _forward_cpu(v, theta)
+        ATAv = _backward_cpu(Av, theta, n)
+        norm2 = np.sqrt(np.sum(ATAv**2) / (np.sum(v**2) + 1e-30))
+        v = ATAv / (np.linalg.norm(ATAv) + 1e-30)
+    tau   = 0.9 / np.sqrt(float(norm2) + 8.0)
+    sigma = tau
+
+    x     = np.zeros((n, n))
+    x_bar = x.copy()
+    py    = np.zeros_like(x)
+    px    = np.zeros_like(x)
+    q     = np.zeros_like(sinogram)
+
+    for it in range(n_iter):
+        Ax_bar = _forward_cpu(x_bar, theta)
+        q      = _prox_l2_data_dual(q + sigma * Ax_bar, sinogram, sigma)
+
+        gy, gx = _grad2d(x_bar)
+        py, px = _prox_tv_dual(py + sigma * gy, px + sigma * gx, lam)
+
+        AT_q  = _backward_cpu(q, theta, n)
+        div_p = _div2d(py, px)
+        x_new = np.maximum(x - tau * (AT_q + div_p), 0.0)
+
+        x_bar = 2.0 * x_new - x
+        x     = x_new
+
+        if verbose and (it % 10 == 0):
+            gy_x, gx_x = _grad2d(x)
+            cost = (0.5 * np.sum((_forward_cpu(x, theta) - sinogram)**2)
+                    + lam * np.sum(np.sqrt(gy_x**2 + gx_x**2)))
+            print("  iter {:4d}  cost = {:.6e}".format(it, cost))
+
+    return x
+
+
+# ---------------------------------------------------------------------------
+# High-level wrapper
+# ---------------------------------------------------------------------------
+
+def tv_reconstruction(
+    sinogram,
+    theta,
+    lam=1e-2,
+    n_iter=100,
+    output_size=None,
+    init="fbp",
+    cuda=False,
+    verbose=False,
+):
+    """
+    TV-regularised tomographic reconstruction.
+
+    High-level wrapper around :func:`chambolle_pock_tv` with an optional
+    FBP warm-start and the same sinogram-axis convention used throughout
+    toupy (detector pixels along axis 0).
+
+    Parameters
+    ----------
+    sinogram : ndarray, shape (n_pixels, n_angles)
+        Sinogram — same axis convention as :func:`mod_iradon`.
+    theta : array_like, shape (n_angles,)
+        Projection angles in degrees.
+    lam : float, optional
+        TV regularisation weight.  Default 1e-2.
+    n_iter : int, optional
+        Number of Chambolle-Pock iterations.  Default 100.
+    output_size : int or None, optional
+        Side length of the square reconstruction grid.  ``None`` infers
+        from the sinogram (matches ``skimage.transform.radon``).
+    init : {'fbp', 'zeros'}, optional
+        Initialisation strategy.  ``'fbp'`` uses a Ram-Lak FBP as the
+        starting point (recommended; faster convergence).  ``'zeros'``
+        starts from the zero image.  Default ``'fbp'``.
+    cuda : bool, optional
+        Run on GPU via CuPy.  Default False.
+    verbose : bool, optional
+        Print cost every 10 iterations.  Default False.
+
+    Returns
+    -------
+    recons : ndarray, shape (n, n)
+        Reconstructed image.
+
+    Notes
+    -----
+    The TV weight *lam* should be tuned to the noise level.  A
+    cross-validation or L-curve approach is recommended for quantitative
+    work.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skimage.transform import radon
+    >>> from toupy.simulation import phantom
+    >>> from toupy.tomo import tv_reconstruction
+    >>> img = phantom(256)
+    >>> theta = np.linspace(0, 180, 180, endpoint=False)
+    >>> sino = radon(img, theta=theta, circle=False)
+    >>> recons = tv_reconstruction(sino, theta, lam=0.01, n_iter=50)
+    """
+    theta    = np.asarray(theta, dtype=float)
+    sinogram = np.asarray(sinogram, dtype=float)
+
+    return chambolle_pock_tv(
+        sinogram, theta,
+        lam=lam,
+        n_iter=n_iter,
+        output_size=output_size,
+        cuda=cuda,
+        verbose=verbose,
+    )

--- a/tutorial/example_iterative_phase_retrieval.py
+++ b/tutorial/example_iterative_phase_retrieval.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Example: nonlinear iterative phase retrieval vs TIE-Hom (Paganin).
+
+TIE-Hom is a *first-order* (single-fringe) phase-retrieval filter.  When the
+propagation distance is large enough that the projection shows **several
+Fresnel fringes** (small Fresnel number), or when δ/β is large, the Paganin
+filter blurs the image and the recovered grey levels are no longer
+quantitative.
+
+This example shows how to refine the TIE-Hom result with
+``iterative_phase_retrieval``, which inverts the **exact** Fresnel forward
+model (angular-spectrum propagation) by nonlinear conjugate-gradient
+minimisation, using TIE-Hom as the initial guess.  It demonstrates:
+
+    1.  Single-distance refinement in the multi-fringe regime
+        (TIE-Hom blurs → iterative sharpens and becomes quantitative).
+    2.  Multi-distance NONLINEAR holotomography, which stays valid for
+        strong phase where the linear CTF breaks down.
+
+Run with:
+    python tutorial/example_iterative_phase_retrieval.py
+"""
+
+import os
+import sys
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+try:
+    import cupy as cp          # noqa: F401
+    GPU_AVAILABLE = True
+    print("CuPy detected — GPU path available (pass cuda=True).")
+except ImportError:
+    GPU_AVAILABLE = False
+    print("CuPy not found — running on CPU.")
+
+from toupy.simulation import phantom
+from toupy.restoration import tie_hom, iterative_phase_retrieval
+
+# ---------------------------------------------------------------------------
+# 0. Parameters
+# ---------------------------------------------------------------------------
+N          = 256
+PIXEL_SIZE = 50e-9
+ENERGY_keV = 17.0
+WAVELENGTH = 1.23984193e-6 / (ENERGY_keV * 1e3)
+DELTA_BETA = 20.0                       # homogeneous object
+
+# Multi-fringe regime: a practical (effective) propagation distance that
+# produces several Fresnel fringes per edge — exactly where TIE-Hom struggles.
+Z_SINGLE   = 0.8e-3                      # 0.8 mm  -> NF ≈ 0.043
+Z_MULTI    = [3e-5, 1.5e-4, 6e-4, 2.4e-3]   # holotomographic distance series
+
+NF = PIXEL_SIZE**2 / (WAVELENGTH * Z_SINGLE)
+print("Wavelength       : {:.4e} m".format(WAVELENGTH))
+print("Fresnel NF (z={:.1f}mm) : {:.3f}  (multi-fringe)".format(Z_SINGLE * 1e3, NF))
+
+# ---------------------------------------------------------------------------
+# 1. Homogeneous phantom INSIDE the field of view (vacuum margin) so that the
+#    propagation fringes are captured by the detector.
+# ---------------------------------------------------------------------------
+MARGIN = 64
+core   = N - 2 * MARGIN
+obj    = phantom(core, phantom_type="Modified Shepp-Logan") * 1.0   # ~1 rad peak
+phase_true = np.zeros((N, N))
+phase_true[MARGIN:MARGIN + core, MARGIN:MARGIN + core] = obj
+mask = phase_true > 0           # object support (for quantitative metrics)
+
+
+# ---------------------------------------------------------------------------
+# 2. Forward model: homogeneous object propagated with the angular spectrum.
+# ---------------------------------------------------------------------------
+def simulate(distance, pad=2, seed=7):
+    """Return the noisy detector intensity for the homogeneous phantom."""
+    M = N * pad
+    o = (M - N) // 2
+    fy = np.fft.fftfreq(M, d=PIXEL_SIZE)
+    fx = np.fft.fftfreq(M, d=PIXEL_SIZE)
+    FY, FX = np.meshgrid(fy, fx, indexing="ij")
+    H = np.exp(1j * np.pi * WAVELENGTH * distance * (FY**2 + FX**2))
+    c = (-1.0 / DELTA_BETA + 1j)
+    field = np.zeros((M, M), dtype=complex)
+    field[o:o + N, o:o + N] = np.exp(c * phase_true)
+    field[:o, :] = 1.0; field[o + N:, :] = 1.0       # vacuum surround
+    field[:, :o] = 1.0; field[:, o + N:] = 1.0
+    psz = np.fft.ifft2(np.fft.fft2(field) * H)
+    I = (np.abs(psz)**2)[o:o + N, o:o + N]
+    rng = np.random.default_rng(seed)
+    return np.maximum(I + rng.normal(0, 0.005 * I.mean(), I.shape), 0)
+
+
+def rmse_abs(a, b):
+    return np.sqrt(np.mean((a[mask] - b[mask])**2))
+
+
+def corr(a, b):
+    return np.corrcoef(a[mask], b[mask])[0, 1]
+
+
+# ---------------------------------------------------------------------------
+# 3. Single-distance: TIE-Hom vs iterative refinement
+# ---------------------------------------------------------------------------
+print("\n--- Single distance (multi-fringe) ---")
+I_single = simulate(Z_SINGLE)
+
+phase_tie = tie_hom(I_single, Z_SINGLE, WAVELENGTH, PIXEL_SIZE,
+                    delta_beta=DELTA_BETA, regularisation=1e-3)
+
+# Total-variation regularisation (reg_tv) flattens the residual Fresnel
+# ripples in the homogeneous interior while preserving the sharp edges —
+# giving a single-distance result close to the multi-distance one.
+phase_iter = iterative_phase_retrieval(
+    I_single, Z_SINGLE, WAVELENGTH, PIXEL_SIZE,
+    delta_beta=DELTA_BETA, init=phase_tie, n_iter=300,
+    reg_smooth=0.0, reg_tv=3e-3, verbose=True,
+)
+
+print("  TIE-Hom    : abs-RMSE = {:.4f} rad   corr = {:.4f}".format(
+    rmse_abs(phase_tie, phase_true), corr(phase_tie, phase_true)))
+print("  Iterative  : abs-RMSE = {:.4f} rad   corr = {:.4f}".format(
+    rmse_abs(phase_iter, phase_true), corr(phase_iter, phase_true)))
+
+# ---------------------------------------------------------------------------
+# 4. Multi-distance NONLINEAR holotomography
+# ---------------------------------------------------------------------------
+print("\n--- Multi-distance nonlinear holotomography ---")
+I_multi = np.array([simulate(z) for z in Z_MULTI])
+phase_holo = iterative_phase_retrieval(
+    I_multi, Z_MULTI, WAVELENGTH, PIXEL_SIZE,
+    delta_beta=DELTA_BETA, n_iter=300, reg_smooth=1e-4,
+)
+print("  Holo (NL)  : abs-RMSE = {:.4f} rad   corr = {:.4f}".format(
+    rmse_abs(phase_holo, phase_true), corr(phase_holo, phase_true)))
+
+# ---------------------------------------------------------------------------
+# 5. Figure
+# ---------------------------------------------------------------------------
+vmin, vmax = phase_true.min(), phase_true.max() * 1.05
+panels = [
+    (phase_true,  "Ground truth"),
+    (phase_tie,   "TIE-Hom\n(blurred, multi-fringe)"),
+    (phase_iter,  "Iterative (single z)\nfull Fresnel model"),
+    (phase_holo,  "Iterative (4 z)\nnonlinear holotomography"),
+]
+fig, axes = plt.subplots(1, 4, figsize=(17, 4))
+for ax, (img, title) in zip(axes, panels):
+    im = ax.imshow(img, cmap="gray", vmin=vmin, vmax=vmax)
+    ax.set_title(title, fontsize=9)
+    ax.axis("off")
+    plt.colorbar(im, ax=ax, fraction=0.046)
+plt.suptitle(
+    "Nonlinear iterative phase retrieval  "
+    "({:.0f} keV, pixel {:.0f} nm, z = {:.1f} mm, NF = {:.3f}, δ/β = {:.0f})".format(
+        ENERGY_keV, PIXEL_SIZE * 1e9, Z_SINGLE * 1e3, NF, DELTA_BETA),
+    fontsize=11)
+plt.tight_layout(rect=[0, 0, 1, 0.95])
+plt.savefig("iterative_phase_retrieval.png", dpi=150, bbox_inches="tight")
+print("\nSaved iterative_phase_retrieval.png")
+
+# Line profile through the object centre (quantitative comparison)
+row = N // 2
+fig, ax = plt.subplots(1, 1, figsize=(8, 4))
+ax.plot(phase_true[row], "k-", lw=2, label="ground truth")
+ax.plot(phase_tie[row],  "C3--", label="TIE-Hom")
+ax.plot(phase_iter[row], "C0-", label="iterative (single z)")
+ax.plot(phase_holo[row], "C2-", label="iterative (multi z)")
+ax.set_xlabel("pixel"); ax.set_ylabel("phase [rad]")
+ax.set_title("Central line profile — quantitative grey levels")
+ax.legend(fontsize=8)
+plt.tight_layout()
+plt.savefig("iterative_phase_profile.png", dpi=150)
+print("Saved iterative_phase_profile.png")
+print("\nDone.")

--- a/tutorial/example_iterative_phase_tomography.py
+++ b/tutorial/example_iterative_phase_tomography.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Example: full phase-contrast TOMOGRAPHY pipeline with iterative phase retrieval.
+
+This extends ``example_iterative_phase_retrieval.py`` (single 2-D projection)
+to a complete tomographic reconstruction:
+
+    1.  A homogeneous slice (projected refractive-index map) is rotated;
+        its line integrals form the clean phase sinogram.
+    2.  For every projection angle the wavefield is propagated (Fresnel /
+        angular spectrum) to give the measured intensity — for a single
+        distance AND for a 4-distance holotomographic series.
+    3.  Each projection is phase-retrieved three ways:
+            - TIE-Hom (Paganin)
+            - iterative, single distance      (full Fresnel model + TV)
+            - iterative, 4 distances          (nonlinear holotomography)
+    4.  The retrieved sinograms are reconstructed by FBP and compared to the
+        ground-truth slice.
+
+Physics note
+------------
+For a single slice the object is invariant along the rotation axis, so the
+2-D Fresnel propagation reduces EXACTLY to a 1-D problem along the detector.
+Each projection is therefore retrieved as a 1-D line (fast), and the loop over
+~150 angles runs in well under a minute on a CPU.  Pass ``cuda=True`` to the
+retrieval calls to use the GPU.
+
+The object is scaled so the maximum projected phase is ~1.2 rad: tomographic
+line integrals accumulate phase over the whole ray, and keeping it below ~pi
+avoids phase-wrapping ambiguity in single-distance retrieval.
+
+Run with:
+    python tutorial/example_iterative_phase_tomography.py
+"""
+
+import os
+import sys
+import time
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from skimage.transform import radon, iradon
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+try:
+    from tqdm import tqdm
+except ImportError:                       # pragma: no cover
+    def tqdm(x, **k):
+        return x
+
+try:
+    import cupy as cp          # noqa: F401
+    GPU_AVAILABLE = True
+    print("CuPy detected — pass cuda=True to the retrieval calls for GPU.")
+except ImportError:
+    GPU_AVAILABLE = False
+    print("CuPy not found — running on CPU.")
+
+from toupy.simulation import phantom
+from toupy.restoration import (tie_hom, iterative_phase_retrieval,
+                               suggest_holo_distances)
+
+# ---------------------------------------------------------------------------
+# 0. Parameters
+# ---------------------------------------------------------------------------
+N          = 192
+PIXEL_SIZE = 50e-9
+ENERGY_keV = 17.0
+WAVELENGTH = 1.23984193e-6 / (ENERGY_keV * 1e3)
+DELTA_BETA = 20.0
+N_ANGLES   = 150
+THETA      = np.linspace(0, 180, N_ANGLES, endpoint=False)
+
+Z_SINGLE   = 0.8e-3                          # NF ≈ 0.043 (multi-fringe)
+MARGIN     = 48                             # vacuum margin (captures fringes)
+N_ITER     = 120
+MAX_PHASE  = 1.2                            # peak projected phase [rad]
+
+# Holotomographic distance series chosen automatically from the CTF-zero
+# interleaving rules (geometric spacing, zero-free shortest distance).
+Z_MULTI, holo_info = suggest_holo_distances(
+    PIXEL_SIZE, WAVELENGTH, n=4, delta_beta=DELTA_BETA, return_info=True)
+
+NF = PIXEL_SIZE**2 / (WAVELENGTH * Z_SINGLE)
+print("Fresnel NF (single z = {:.1f} mm) : {:.3f}".format(Z_SINGLE * 1e3, NF))
+print("Suggested 4-z series [µm]   : {}  (ratio R = {:.2f})".format(
+    ", ".join("{:.1f}".format(z * 1e6) for z in Z_MULTI), holo_info["ratio"]))
+print("  per-distance NF           : {}".format(
+    ", ".join("{:.3f}".format(v) for v in holo_info["NF"])))
+print("  worst combined transfer   : {:.3f}  (gap-free if > ~0.02)".format(
+    holo_info["min_coverage"]))
+
+# ---------------------------------------------------------------------------
+# 1. Ground-truth slice and clean phase sinogram
+# ---------------------------------------------------------------------------
+slice_raw  = phantom(N, phantom_type="Modified Shepp-Logan")
+sino_clean = radon(slice_raw, theta=THETA, circle=True)
+scale      = MAX_PHASE / sino_clean.max()
+slice_true = slice_raw * scale
+sino_clean = sino_clean * scale
+n_det      = sino_clean.shape[0]
+L          = n_det + 2 * MARGIN
+print("Sinogram (n_det x n_ang):", sino_clean.shape,
+      " max projected phase = {:.2f} rad".format(sino_clean.max()))
+
+
+# ---------------------------------------------------------------------------
+# 2. 1-D Fresnel forward model for one projection line
+# ---------------------------------------------------------------------------
+def propagate_line(proj, distance):
+    """Return the detector intensity (length L, vacuum=1 margins) for one
+    homogeneous projection line propagated over *distance*."""
+    pe = np.zeros(L)
+    pe[MARGIN:MARGIN + n_det] = proj
+    M = L * 2
+    o = (M - L) // 2
+    fx = np.fft.fftfreq(M, d=PIXEL_SIZE)
+    H = np.exp(1j * np.pi * WAVELENGTH * distance * fx**2)
+    c = (-1.0 / DELTA_BETA + 1j)
+    field = np.ones(M, dtype=complex)              # vacuum = 1 outside object
+    field[o:o + L] = np.exp(c * pe)
+    inten = np.abs(np.fft.ifft2(
+        np.fft.fft2(field.reshape(1, -1)) * H.reshape(1, -1)))**2
+    return inten[0][o:o + L]
+
+
+rng = np.random.default_rng(0)
+
+
+def add_noise(I, level=0.005):
+    return np.maximum(I + rng.normal(0, level * I.mean(), I.shape), 0)
+
+
+# ---------------------------------------------------------------------------
+# 3. Per-angle phase retrieval (TIE-Hom, iterative 1z, iterative 4z)
+# ---------------------------------------------------------------------------
+sino_tie  = np.zeros_like(sino_clean)
+sino_it1  = np.zeros_like(sino_clean)
+sino_it4  = np.zeros_like(sino_clean)
+
+print("\nRetrieving {} projections (3 methods)...".format(N_ANGLES))
+t0 = time.perf_counter()
+for k in tqdm(range(N_ANGLES)):
+    col = sino_clean[:, k]
+
+    # --- single distance ---
+    I1 = add_noise(propagate_line(col, Z_SINGLE))[None, :]
+    sino_tie[:, k] = tie_hom(
+        I1, Z_SINGLE, WAVELENGTH, PIXEL_SIZE, delta_beta=DELTA_BETA
+    )[0][MARGIN:MARGIN + n_det]
+    sino_it1[:, k] = iterative_phase_retrieval(
+        I1, Z_SINGLE, WAVELENGTH, PIXEL_SIZE, delta_beta=DELTA_BETA,
+        n_iter=N_ITER, reg_tv=3e-3,
+    )[0][MARGIN:MARGIN + n_det]
+
+    # --- multi distance (holotomography) ---
+    I4 = add_noise(np.array([propagate_line(col, z) for z in Z_MULTI]))
+    sino_it4[:, k] = iterative_phase_retrieval(
+        I4[:, None, :], Z_MULTI, WAVELENGTH, PIXEL_SIZE, delta_beta=DELTA_BETA,
+        n_iter=N_ITER, reg_tv=1e-3,
+    )[0][MARGIN:MARGIN + n_det]
+print("  retrieval done in {:.1f} s".format(time.perf_counter() - t0))
+
+# ---------------------------------------------------------------------------
+# 4. Tomographic reconstruction (FBP)
+# ---------------------------------------------------------------------------
+def fbp(sino):
+    return iradon(sino, theta=THETA, filter_name="ramp", circle=True)
+
+
+rec_true = fbp(sino_clean)
+rec_tie  = fbp(sino_tie)
+rec_it1  = fbp(sino_it1)
+rec_it4  = fbp(sino_it4)
+
+
+def normalise(x):
+    return (x - x.min()) / (x.max() - x.min() + 1e-30)
+
+
+def rmse(a):
+    return np.sqrt(np.mean((normalise(a) - normalise(slice_true))**2))
+
+
+print("\n--- Tomogram RMSE (normalised, vs ground-truth slice) ---")
+print("  FBP(clean sinogram)        : {:.4f}".format(rmse(rec_true)))
+print("  FBP(TIE-Hom retrieved)     : {:.4f}".format(rmse(rec_tie)))
+print("  FBP(iterative single-z)    : {:.4f}".format(rmse(rec_it1)))
+print("  FBP(iterative 4-z holo)    : {:.4f}".format(rmse(rec_it4)))
+
+# ---------------------------------------------------------------------------
+# 5. Figures
+# ---------------------------------------------------------------------------
+panels = [
+    (slice_true, "Ground-truth slice"),
+    (rec_tie,    "FBP  •  TIE-Hom\nphase retrieval"),
+    (rec_it1,    "FBP  •  iterative single-z\n(full Fresnel + TV)"),
+    (rec_it4,    "FBP  •  iterative 4-z\n(nonlinear holotomography)"),
+]
+vmin, vmax = slice_true.min(), slice_true.max() * 1.05
+fig, axes = plt.subplots(1, 4, figsize=(17, 4.5))
+for ax, (img, title) in zip(axes, panels):
+    im = ax.imshow(img, cmap="gray", vmin=vmin, vmax=vmax)
+    ax.set_title(title, fontsize=9)
+    ax.axis("off")
+    plt.colorbar(im, ax=ax, fraction=0.046)
+plt.suptitle(
+    "Phase-contrast tomography: TIE-Hom vs iterative phase retrieval  "
+    "({:.0f} keV, {:.0f} nm, z = {:.1f} mm, NF = {:.3f}, δ/β = {:.0f})".format(
+        ENERGY_keV, PIXEL_SIZE * 1e9, Z_SINGLE * 1e3, NF, DELTA_BETA),
+    fontsize=11)
+plt.tight_layout(rect=[0, 0, 1, 0.93])
+plt.savefig("iterative_phase_tomography.png", dpi=150, bbox_inches="tight")
+print("\nSaved iterative_phase_tomography.png")
+
+# Line profile through the reconstructed slice centre
+row = N // 2
+fig, ax = plt.subplots(1, 1, figsize=(8, 4))
+ax.plot(slice_true[row], "k-", lw=2, label="ground truth")
+ax.plot(rec_tie[row], "C3--", label="TIE-Hom")
+ax.plot(rec_it1[row], "C0-", label="iterative single-z")
+ax.plot(rec_it4[row], "C2-", label="iterative 4-z")
+ax.set_xlabel("pixel"); ax.set_ylabel("reconstructed value")
+ax.set_title("Central line profile through the tomogram")
+ax.legend(fontsize=8)
+plt.tight_layout()
+plt.savefig("iterative_phase_tomography_profile.png", dpi=150)
+print("Saved iterative_phase_tomography_profile.png")
+
+# ---------------------------------------------------------------------------
+# 6. Frequency-space view — WHY single-distance has gaps and multi-z fills them
+# ---------------------------------------------------------------------------
+# Homogeneous phase transfer function at distance z:
+#     w_z(u) = sin(chi) + eps*cos(chi),   chi = pi*lambda*z*u^2,  eps = 1/(delta/beta)
+# Phase is lost where w_z(u) = 0.  The pure-phase part sin(chi) vanishes at
+#     chi = n*pi   ->   u_n = sqrt( n / (lambda*z) ),   n = 1, 2, 3, ...
+# i.e. in units of the Nyquist frequency u_Nyq = 1/(2*pixel):
+#     f_n = u_n / u_Nyq = 2 * sqrt( n * NF ),   NF = pixel^2 / (lambda*z).
+# Spacing the distances geometrically makes these zeros INTERLEAVE, so the
+# combined coverage never drops to zero.
+u_nyq = 1.0 / (2 * PIXEL_SIZE)
+u = np.linspace(0, u_nyq, 2000)
+fnorm = u / u_nyq
+eps = 1.0 / DELTA_BETA
+
+
+def transfer(z):
+    chi = np.pi * WAVELENGTH * z * u**2
+    return np.sin(chi) + eps * np.cos(chi)
+
+
+fig, (axA, axB) = plt.subplots(1, 2, figsize=(13, 4.2))
+
+# Panel A — single distance (gaps) vs combined multi-z coverage
+axA.plot(fnorm, np.abs(transfer(Z_SINGLE)), "C3",
+         label="single  z = {:.1f} mm".format(Z_SINGLE * 1e3))
+combined = np.sqrt(np.mean([transfer(z)**2 for z in Z_MULTI], axis=0))
+axA.plot(fnorm, combined, "C2", lw=2.2,
+         label=r"4-z combined  $\sqrt{\langle w_z^2\rangle}$")
+axA.axhline(0, color="k", lw=0.5)
+axA.set_xlabel(r"spatial frequency  $u/u_{\mathrm{Nyq}}$")
+axA.set_ylabel("|phase transfer|")
+axA.set_title("Single distance dips to zero at its CTF zeros (gaps);\n"
+              "the 4-z combination stays bounded away from zero")
+axA.legend(fontsize=8)
+
+# Panel B — individual distances: interleaved zeros
+for z in Z_MULTI:
+    nf = PIXEL_SIZE**2 / (WAVELENGTH * z)
+    axB.plot(fnorm, np.abs(transfer(z)),
+             label="z = {:6.0f} µm  (NF = {:.2f})".format(z * 1e6, nf))
+axB.set_xlabel(r"spatial frequency  $u/u_{\mathrm{Nyq}}$")
+axB.set_ylabel(r"$|w_z(u)|$")
+axB.set_title(r"Individual distances: zeros at $u_n=\sqrt{n/(\lambda z)}$"
+              "\nshort z → low-freq, long z → high-freq")
+axB.legend(fontsize=8)
+
+plt.tight_layout()
+plt.savefig("ctf_frequency_coverage.png", dpi=150)
+print("Saved ctf_frequency_coverage.png")
+print("\nDone.")

--- a/tutorial/example_phase_retrieval_tv_ring.py
+++ b/tutorial/example_phase_retrieval_tv_ring.py
@@ -1,0 +1,557 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Example: Phase retrieval, ring correction, and TV reconstruction.
+
+Demonstrates the full synchrotron / ptychographic nanotomography
+pre-processing pipeline using simulated data:
+
+    1.  Create a Shepp-Logan phantom as the projected phase object.
+    2.  Simulate free-space propagation (TIE forward model) to get
+        intensity projections, then recover the phase with:
+            - TIE-Hom  (Paganin 2002)
+            - CTF inversion
+    3.  Inject synthetic ring artifacts into the sinogram and remove
+        them with:
+            - Wavelet-FFT filter (Münch 2009)
+            - Titarenko analytical correction
+    4.  Reconstruct with:
+            - Standard FBP (Ram-Lak filter)
+            - TV-regularised FBP (Chambolle-Pock)
+    5.  Display and compare all results.
+
+Run with:
+    python tutorial/example_phase_retrieval_tv_ring.py
+"""
+
+import time
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")      # headless; change to 'TkAgg' for interactive
+import matplotlib.pyplot as plt
+from matplotlib.gridspec import GridSpec
+from skimage.transform import radon, iradon
+
+# toupy imports
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# ---------------------------------------------------------------------------
+# GPU availability check (informational only — all functions fall back to
+# CPU automatically when CuPy is not installed)
+# ---------------------------------------------------------------------------
+try:
+    import cupy as cp
+    GPU_AVAILABLE = True
+    print("CuPy detected — GPU path enabled.")
+except ImportError:
+    GPU_AVAILABLE = False
+    print("CuPy not found — running on CPU only.")
+
+from toupy.simulation import phantom
+from toupy.restoration import tie_hom, ctf_retrieve
+from toupy.restoration import remove_rings_wavelet_fft, remove_rings_titarenko
+from toupy.tomo import tv_reconstruction, mod_iradon
+
+# ---------------------------------------------------------------------------
+# 0. Experimental parameters
+# ---------------------------------------------------------------------------
+# Detector pixel / energy are representative of a zone-plate nanotomography
+# setup at 17 keV (e.g. ID16A at ESRF).
+#
+# PROPAGATION DISTANCES for phase retrieval:
+#   Phase-contrast methods require the Fresnel number NF = pixel²/(λ·z) to
+#   be in the range 0.1–2 for meaningful contrast transfer.  For 50 nm pixels
+#   at 17 keV this corresponds to an *effective* propagation distance of
+#   roughly 30–200 µm.  In zone-plate optics this "effective z" arises from
+#   the focal-length geometry of the objective, not the physical
+#   sample-to-detector separation.  We choose:
+#
+#     z_TIE = 40 µm  →  NF ≈ 0.86  (near-field: best TIE-Hom validity)
+#     z_CTF = 30 µm  →  NF ≈ 1.14  (near-field: widest first CTF passband)
+#
+# Choosing a SHORT distance (large NF) keeps the higher-order Fresnel
+# fringes weak, so the first-order TIE / CTF inversions remain accurate.
+# Longer distances increase contrast but also the model mismatch (and the
+# negative low-frequency halo of single-distance retrieval).
+# ---------------------------------------------------------------------------
+
+N          = 256                # phantom / detector size [pixels]
+PIXEL_SIZE = 50e-9              # effective pixel size at sample [m]  (50 nm)
+ENERGY_keV = 17.0               # X-ray energy [keV]
+DELTA_BETA = 50.0               # delta/beta ratio — moderate-Z material at 17 keV
+                                # (lower δ/β ⇒ stronger relative absorption ⇒
+                                #  more faithful single-distance TIE-Hom)
+N_ANGLES   = 180                # number of projection angles
+THETA      = np.linspace(0, 180, N_ANGLES, endpoint=False)  # [degrees]
+
+Z_TIE = 40e-6                   # effective propagation distance for TIE-Hom [m]
+Z_CTF = 30e-6                   # effective propagation distance for CTF [m]
+
+# Multi-distance / holotomographic CTF: several propagation distances whose
+# CTF zeros interleave.  All stay below the single-FFT Fresnel-sampling limit
+# z_crit = N·pixel²/λ ≈ 8.8 mm so the simulated propagation is alias-free.
+Z_HOLO = [30e-6, 150e-6, 600e-6, 2.4e-3]   # [m]
+
+# Derived
+hc_eV_m    = 1.23984193e-6      # hc [eV·m]
+WAVELENGTH = hc_eV_m / (ENERGY_keV * 1e3)   # [m]
+
+print("Wavelength        : {:.4e} m".format(WAVELENGTH))
+print("Fresnel NF (TIE)  : {:.3f}".format(PIXEL_SIZE**2 / (WAVELENGTH * Z_TIE)))
+print("Fresnel NF (CTF)  : {:.3f}".format(PIXEL_SIZE**2 / (WAVELENGTH * Z_CTF)))
+
+# ---------------------------------------------------------------------------
+# 1. Phantom: projected phase and absorption (Paganin homogeneous assumption)
+#
+#    For TIE-Hom (Paganin) retrieval to work the object must be "homogeneous":
+#    absorption and phase are linked by  mu*T = 2 * phi / (delta/beta).
+#    We use the Shepp-Logan phantom values as the PHASE map and derive the
+#    absorption from it.  Peak phase ~5 rad is typical for bone at 17 keV
+#    over ~60 µm sample thickness.
+#
+#    For CTF we need a WEAK-phase object (|phi| << 1 rad) because the CTF
+#    inversion is a linearised approximation valid only in that regime.
+#    We therefore demonstrate CTF with a separate, scaled-down phantom.
+# ---------------------------------------------------------------------------
+
+phase_true    = phantom(N, phantom_type="Modified Shepp-Logan") * 5.0  # [rad]
+phase_true_wk = phantom(N, phantom_type="Modified Shepp-Logan") * 0.3  # weak-phase for CTF
+
+fig, ax = plt.subplots(1, 1, figsize=(4, 4))
+im = ax.imshow(phase_true, cmap="gray")
+ax.set_title("Ground-truth projected phase [rad]")
+plt.colorbar(im, ax=ax, fraction=0.046)
+plt.tight_layout()
+plt.savefig("phase_true.png", dpi=150)
+print("Saved phase_true.png")
+
+# ---------------------------------------------------------------------------
+# 2. Simulate free-space propagation using the angular spectrum method.
+#
+#    This is the physically correct forward model for any object thickness.
+#    The linearised TIE forward model (I ≈ 1 - z*λ/(4π)·∇²φ) is only valid
+#    for very small phase values and would produce unphysical (negative)
+#    intensities for |φ| >> 1 rad.
+#
+#    For TIE-Hom: mixed object following the Paganin homogeneity assumption
+#        ψ_in = exp(-mu_T/2) · exp(i·φ),   mu_T = 2·φ / (δ/β)
+#    For CTF:     pure phase object (weakly scattering)
+#        ψ_in = exp(i·φ_weak)
+# ---------------------------------------------------------------------------
+
+print("\n--- Simulating propagation (angular spectrum) ---")
+
+
+def propagate_angular_spectrum(psi_in, distance, wavelength, pixel_size, pad=1):
+    """Free-space propagation via the paraxial angular spectrum method.
+
+    Returns the intensity |ψ_prop|² at the detector plane.
+    Valid for any phase magnitude; no linear approximations.
+
+    ``pad`` (>1) zero/vacuum-pads the field before propagation to avoid
+    circular wrap-around of the Fresnel kernel at longer distances, then
+    crops back to the original field of view.
+    """
+    ny, nx = psi_in.shape
+    if pad > 1:
+        my, mx = ny * pad, nx * pad
+        oy, ox = (my - ny) // 2, (mx - nx) // 2
+        field = np.ones((my, mx), dtype=complex)   # vacuum = 1
+        field[oy:oy + ny, ox:ox + nx] = psi_in
+    else:
+        my, mx, oy, ox, field = ny, nx, 0, 0, psi_in
+    fy = np.fft.fftfreq(my, d=pixel_size)
+    fx = np.fft.fftfreq(mx, d=pixel_size)
+    FY, FX = np.meshgrid(fy, fx, indexing="ij")
+    # Fresnel (paraxial) propagator
+    H = np.exp(1j * np.pi * wavelength * distance * (FY**2 + FX**2))
+    psi_prop = np.fft.ifft2(np.fft.fft2(field) * H)
+    intensity = np.abs(psi_prop)**2
+    return intensity[oy:oy + ny, ox:ox + nx] if pad > 1 else intensity
+
+
+# --- TIE-Hom simulation: mixed object obeying Paganin's assumption ---
+# Absorption is linked to phase by the homogeneity condition:
+#   mu*T = 2 * phi / (delta/beta)
+# Both contribute to the transmitted wave:  psi = exp(-mu_T/2 + i*phi)
+mu_T    = 2.0 * phase_true / DELTA_BETA
+psi_mix = np.exp(-mu_T / 2.0 + 1j * phase_true)
+I_tiehom = propagate_angular_spectrum(psi_mix, Z_TIE, WAVELENGTH, PIXEL_SIZE)
+rng_ph = np.random.default_rng(7)
+I_tiehom_noisy = I_tiehom + rng_ph.normal(0, 0.005 * I_tiehom.mean(), I_tiehom.shape)
+I_tiehom_noisy = np.maximum(I_tiehom_noisy, 0)
+
+# --- CTF simulation: pure weak-phase object (|phi| << 1 rad) ---
+# CTF is the linearised approximation  I ≈ 1 + 2*CTF*phi, valid only for
+# |phi| << 1 rad.  We use a separate scaled phantom (max 0.3 rad).
+psi_wk  = np.exp(1j * phase_true_wk)
+I_ctf   = propagate_angular_spectrum(psi_wk, Z_CTF, WAVELENGTH, PIXEL_SIZE)
+I_ctf_noisy = I_ctf + rng_ph.normal(0, 0.002 * I_ctf.mean(), I_ctf.shape)
+I_ctf_noisy = np.maximum(I_ctf_noisy, 0)
+
+# --- Holotomographic (multi-distance) CTF simulation ---
+# A HOMOGENEOUS weak object (same δ/β coupling as TIE-Hom) imaged at several
+# distances.  The absorption term lets the multi-distance CTF recover the low
+# frequencies / DC that single-distance CTF cannot.
+mu_T_wk    = 2.0 * phase_true_wk / DELTA_BETA
+psi_wk_mix = np.exp(-mu_T_wk / 2.0 + 1j * phase_true_wk)
+I_holo = np.array([
+    propagate_angular_spectrum(psi_wk_mix, z, WAVELENGTH, PIXEL_SIZE, pad=2)
+    for z in Z_HOLO
+])
+I_holo_noisy = np.maximum(
+    I_holo + rng_ph.normal(0, 0.002 * I_holo.mean(), I_holo.shape), 0)
+
+print("  TIE-Hom intensity range : [{:.4f}, {:.4f}]".format(
+    I_tiehom_noisy.min(), I_tiehom_noisy.max()))
+print("  CTF     intensity range : [{:.4f}, {:.4f}]".format(
+    I_ctf_noisy.min(), I_ctf_noisy.max()))
+print("  Holo    distances [µm]  : {}".format(
+    [round(z * 1e6, 1) for z in Z_HOLO]))
+
+# ---------------------------------------------------------------------------
+# 3. Phase retrieval — single projection
+# ---------------------------------------------------------------------------
+
+print("\n--- Phase retrieval (single projection) ---")
+
+from scipy.ndimage import gaussian_filter
+
+# TIE-Hom: pre-smooth the intensity by ~1.5 pixels before retrieval.
+#
+# WHY: the angular spectrum propagation at NF≈0.49 produces Fresnel
+# diffraction fringes at the sharp edges of the Shepp-Logan phantom.
+# The Paganin filter (derived from the near-field TIE approximation)
+# misinterprets these high-frequency edge fringes as phase, creating a
+# halo / ringing artefact around the object boundary.  A mild Gaussian
+# pre-filter mimics the finite PSF of a real detector and brings the
+# measured intensity closer to the smooth TIE model prediction.
+I_tiehom_smooth = gaussian_filter(I_tiehom_noisy, sigma=0.8)
+
+phase_tiehom = tie_hom(
+    I_tiehom_smooth,
+    distance=Z_TIE,
+    wavelength=WAVELENGTH,
+    pixel_size=PIXEL_SIZE,
+    delta_beta=DELTA_BETA,
+    regularisation=1e-3,
+)
+
+# CTF: a moderate Tikhonov α ≈ 1e-2 gives the most robust inversion here.
+# A single propagation distance transfers phase only in a BAND around the
+# first CTF maximum (χ ≈ π/2); too small an α amplifies noise near the CTF
+# zeros without recovering the (unrecoverable) low frequencies.
+phase_ctf = ctf_retrieve(
+    I_ctf_noisy,
+    distance=Z_CTF,
+    wavelength=WAVELENGTH,
+    pixel_size=PIXEL_SIZE,
+    alpha=1e-2,
+)
+
+# CTF background correction:
+#
+# Single-distance CTF is fundamentally a BAND-PASS phase filter: it cannot
+# recover DC or the lowest spatial frequencies because sin(χ→0) = 0.  For
+# the large smooth Shepp-Logan ellipses (χ ≈ 10⁻³ rad) the absolute phase
+# level is NOT retrieved — only the mid/high-frequency structure and the
+# correct contrast polarity.  (Full low-frequency recovery requires either
+# multiple propagation distances / holotomography, or far-field distances.)
+#
+# We set the vacuum background (phase_true_wk ≈ 0) to zero in the CTF output
+# so the phase RELATIVE to vacuum is displayed correctly.
+bg_mask        = (phase_true_wk < 0.01 * phase_true_wk.max())  # vacuum pixels
+phase_ctf     -= phase_ctf[bg_mask].mean()
+
+# --- Holotomographic (multi-distance, homogeneous) CTF retrieval ---
+# Passing a list of distances + delta_beta switches ctf_retrieve into the
+# multi-distance homogeneous mode, which fills the single-distance CTF zeros
+# AND recovers the low frequencies / DC through the absorption term.
+phase_holo = ctf_retrieve(
+    I_holo_noisy,
+    distance=Z_HOLO,
+    wavelength=WAVELENGTH,
+    pixel_size=PIXEL_SIZE,
+    alpha=1e-3,
+    delta_beta=DELTA_BETA,
+)
+
+print("  TIE-Hom phase range  : [{:.3f}, {:.3f}] rad".format(
+    phase_tiehom.min(), phase_tiehom.max()))
+print("  CTF     phase range  : [{:.4f}, {:.4f}] rad".format(
+    phase_ctf.min(), phase_ctf.max()))
+print("  Holo-CTF phase range : [{:.4f}, {:.4f}] rad  (truth 0–0.3)".format(
+    phase_holo.min(), phase_holo.max()))
+
+fig, axes = plt.subplots(1, 4, figsize=(17, 4))
+display_data = [
+    (phase_true,    "Ground truth\n(phase, 0–5 rad)"),
+    (phase_tiehom,  "TIE-Hom retrieved\n(mixed object)"),
+    (phase_ctf,     "Single-distance CTF\n(weak phase, band-pass)"),
+    (phase_holo,    "Holotomographic CTF\n(4 distances + δ/β)"),
+]
+for ax, (img, title) in zip(axes, display_data):
+    im = ax.imshow(img, cmap="gray")
+    ax.set_title(title, fontsize=9)
+    plt.colorbar(im, ax=ax, fraction=0.046)
+plt.tight_layout()
+plt.savefig("phase_retrieval_comparison.png", dpi=150)
+print("Saved phase_retrieval_comparison.png")
+
+# ---------------------------------------------------------------------------
+# 4. Build a full sinogram from phase projections
+#    (simulate ptychographic tomography: we already have the phase per angle)
+# ---------------------------------------------------------------------------
+
+print("\n--- Building sinogram from phase projections ---")
+
+sino_clean = radon(phase_true, theta=THETA, circle=False)
+print("  Sinogram shape (n_pixels x n_angles):", sino_clean.shape)
+
+# ---------------------------------------------------------------------------
+# 5. Inject ring artifacts
+#    Rings appear as additive stripes in the sinogram (column-constant offset)
+# ---------------------------------------------------------------------------
+
+print("\n--- Injecting ring artifacts ---")
+
+rng = np.random.default_rng(42)
+n_rings = 15
+ring_positions = rng.integers(10, sino_clean.shape[0] - 10, size=n_rings)
+ring_amplitudes = rng.uniform(-0.3, 0.3, size=n_rings) * sino_clean.std()
+
+sino_rings = sino_clean.copy()
+for pos, amp in zip(ring_positions, ring_amplitudes):
+    width = rng.integers(1, 4)
+    sino_rings[max(0, pos - width): pos + width, :] += amp
+
+# Add Poisson-like noise (simulating photon statistics)
+sino_noisy = sino_rings + rng.normal(0, 0.02 * sino_clean.std(),
+                                      sino_clean.shape)
+
+fig, axes = plt.subplots(1, 3, figsize=(14, 4))
+for ax, sino, title in zip(
+    axes,
+    [sino_clean, sino_rings, sino_noisy],
+    ["Clean sinogram", "With ring artifacts", "With rings + noise"],
+):
+    ax.imshow(sino, cmap="gray", aspect="auto")
+    ax.set_title(title)
+    ax.set_xlabel("Angle index")
+    ax.set_ylabel("Detector pixel")
+plt.tight_layout()
+plt.savefig("sinogram_comparison.png", dpi=150)
+print("Saved sinogram_comparison.png")
+
+# ---------------------------------------------------------------------------
+# 6. Ring artifact correction
+# ---------------------------------------------------------------------------
+
+print("\n--- Ring artifact correction ---")
+
+sino_wavelet   = remove_rings_wavelet_fft(sino_noisy, level=3, sigma=3)
+sino_titarenko = remove_rings_titarenko(sino_noisy, size=51)
+
+fig, axes = plt.subplots(1, 3, figsize=(14, 4))
+for ax, sino, title in zip(
+    axes,
+    [sino_noisy, sino_wavelet, sino_titarenko],
+    ["Noisy + rings", "Wavelet-FFT corrected", "Titarenko corrected"],
+):
+    ax.imshow(sino, cmap="gray", aspect="auto")
+    ax.set_title(title)
+    ax.set_xlabel("Angle index")
+    ax.set_ylabel("Detector pixel")
+plt.tight_layout()
+plt.savefig("ring_correction_comparison.png", dpi=150)
+print("Saved ring_correction_comparison.png")
+
+# ---------------------------------------------------------------------------
+# 7. Tomographic reconstruction: FBP vs TV
+# ---------------------------------------------------------------------------
+
+print("\n--- Tomographic reconstruction ---")
+
+# FBP from clean sinogram (reference)
+recons_fbp_clean = iradon(sino_clean, theta=THETA, filter_name="ramp",
+                           circle=False)
+
+# FBP from ring-corrupted sinogram
+recons_fbp_rings = iradon(sino_noisy, theta=THETA, filter_name="ramp",
+                           circle=False)
+
+# FBP after wavelet-FFT ring correction
+recons_fbp_corrected = iradon(sino_wavelet, theta=THETA, filter_name="ramp",
+                               circle=False)
+
+# TV reconstruction from ring-corrected sinogram
+print("  Running TV reconstruction (100 iterations)...")
+recons_tv = tv_reconstruction(
+    sino_wavelet,
+    theta=THETA,
+    lam=0.01,
+    n_iter=100,
+    output_size=N,
+    verbose=True,
+)
+
+print("  TV reconstruction done.")
+
+# ---------------------------------------------------------------------------
+# 8. Final comparison figure
+# ---------------------------------------------------------------------------
+
+vmin = phase_true.min() * 0.9
+vmax = phase_true.max() * 1.1
+
+fig = plt.figure(figsize=(16, 8))
+gs = GridSpec(2, 4, figure=fig, hspace=0.3, wspace=0.3)
+
+panels = [
+    (phase_true,           "Ground truth"),
+    (recons_fbp_clean,     "FBP — clean sino"),
+    (recons_fbp_rings,     "FBP — with rings"),
+    (recons_fbp_corrected, "FBP — ring corrected"),
+    (phase_tiehom,         "TIE-Hom phase"),
+    (phase_ctf,            "Single-distance CTF"),
+    (phase_holo,           "Holotomographic CTF"),
+    (recons_tv,            "TV — ring corrected\n(λ=0.01, 100 iter)"),
+]
+
+for idx, (img, title) in enumerate(panels):
+    r, c = divmod(idx, 4)
+    ax = fig.add_subplot(gs[r, c])
+    im = ax.imshow(img, cmap="gray")
+    ax.set_title(title, fontsize=9)
+    ax.axis("off")
+    plt.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+
+plt.suptitle(
+    "Synchrotron nanotomography pipeline\n"
+    "({:.0f} keV, pixel = {:.0f} nm, z_TIE = {:.0f} µm, δ/β = {:.0f})".format(
+        ENERGY_keV, PIXEL_SIZE * 1e9, Z_TIE * 1e6, DELTA_BETA
+    ),
+    fontsize=11,
+)
+plt.savefig("full_pipeline_comparison.png", dpi=150, bbox_inches="tight")
+print("Saved full_pipeline_comparison.png")
+
+# ---------------------------------------------------------------------------
+# 9. Quantitative metrics
+# ---------------------------------------------------------------------------
+
+def rmse(a, b):
+    return np.sqrt(np.mean((a - b) ** 2))
+
+
+def normalise(img):
+    mn, mx = img.min(), img.max()
+    return (img - mn) / (mx - mn + 1e-30)
+
+
+ref = normalise(phase_true)
+print("\n--- RMSE (normalised) ---")
+for label, img in [
+    ("FBP clean",      recons_fbp_clean),
+    ("FBP rings",      recons_fbp_rings),
+    ("FBP corrected",  recons_fbp_corrected),
+    ("TV  corrected",  recons_tv),
+]:
+    print("  {:20s}  RMSE = {:.5f}".format(label, rmse(ref, normalise(img))))
+
+# Phase-retrieval fidelity for the weak-phase object (CTF vs holo-CTF):
+print("\n--- Phase retrieval fidelity (weak-phase object, vs truth) ---")
+for label, img in [
+    ("Single-distance CTF", phase_ctf),
+    ("Holotomographic CTF", phase_holo),
+]:
+    r = np.corrcoef(img.ravel(), phase_true_wk.ravel())[0, 1]
+    print("  {:22s}  RMSE = {:.5f}   corr = {:+.3f}".format(
+        label, rmse(normalise(phase_true_wk), normalise(img)), r))
+
+print("\nAll figures saved. Done.")
+
+# ---------------------------------------------------------------------------
+# 10. GPU demonstration (runs only when CuPy is available)
+#     Shows the cuda=True interface and timing comparison.
+# ---------------------------------------------------------------------------
+
+if GPU_AVAILABLE:
+    print("\n" + "=" * 60)
+    print("GPU demonstration")
+    print("=" * 60)
+
+    # Build a larger stack to make the GPU advantage visible
+    N_GPU     = 512
+    N_ANG_GPU = 360
+    theta_gpu = np.linspace(0, 180, N_ANG_GPU, endpoint=False)
+
+    rng2     = np.random.default_rng(7)
+    ph_stack = phantom(N_GPU)[np.newaxis] * np.ones((10, N_GPU, N_GPU)) * 8.0
+    ph_stack += rng2.normal(0, 0.01, ph_stack.shape)
+
+    # Simulate propagation for the stack (mixed object, Paganin assumption)
+    mu_T_gpu = 2.0 * ph_stack / DELTA_BETA
+    psi_gpu  = np.exp(-mu_T_gpu / 2.0 + 1j * ph_stack)
+    I_stack  = np.array([
+        propagate_angular_spectrum(psi_gpu[k], Z_TIE, WAVELENGTH, PIXEL_SIZE)
+        for k in range(ph_stack.shape[0])
+    ])
+
+    print("\n  Phase retrieval — stack of 10 × {}×{} images".format(N_GPU, N_GPU))
+
+    t0 = time.perf_counter()
+    _ = tie_hom(I_stack, Z_TIE, WAVELENGTH, PIXEL_SIZE,
+                delta_beta=DELTA_BETA, cuda=False)
+    t_cpu = time.perf_counter() - t0
+    print("    CPU  TIE-Hom  : {:.3f} s".format(t_cpu))
+
+    t0 = time.perf_counter()
+    _ = tie_hom(I_stack, Z_TIE, WAVELENGTH, PIXEL_SIZE,
+                delta_beta=DELTA_BETA, cuda=True)
+    t_gpu = time.perf_counter() - t0
+    print("    GPU  TIE-Hom  : {:.3f} s  (speedup {:.1f}×)".format(
+        t_gpu, t_cpu / max(t_gpu, 1e-6)))
+
+    # Ring correction timing on the larger sinogram
+    sino_gpu_test = radon(phantom(N_GPU), theta=theta_gpu, circle=False)
+    rings_test    = sino_gpu_test + rng2.normal(0, 0.05, sino_gpu_test.shape)
+    rings_test[N_GPU // 3, :] += 0.5  # inject one strong ring
+
+    print("\n  Ring correction — sinogram {}×{}".format(*rings_test.shape))
+
+    t0 = time.perf_counter()
+    _ = remove_rings_wavelet_fft(rings_test, level=3, sigma=2.5, cuda=False)
+    t_cpu = time.perf_counter() - t0
+    print("    CPU  wavelet-FFT : {:.3f} s".format(t_cpu))
+
+    t0 = time.perf_counter()
+    _ = remove_rings_wavelet_fft(rings_test, level=3, sigma=2.5, cuda=True)
+    t_gpu = time.perf_counter() - t0
+    print("    GPU  wavelet-FFT : {:.3f} s  (speedup {:.1f}×)".format(
+        t_gpu, t_cpu / max(t_gpu, 1e-6)))
+
+    # TV reconstruction timing
+    sino_tv_gpu = radon(phantom(N_GPU), theta=theta_gpu, circle=False)
+    print("\n  TV reconstruction — {}×{} image, {} angles, 30 iter".format(
+        N_GPU, N_GPU, N_ANG_GPU))
+
+    t0 = time.perf_counter()
+    _ = tv_reconstruction(sino_tv_gpu, theta_gpu, lam=0.01, n_iter=30,
+                          output_size=N_GPU, cuda=False)
+    t_cpu = time.perf_counter() - t0
+    print("    CPU  TV : {:.3f} s".format(t_cpu))
+
+    t0 = time.perf_counter()
+    _ = tv_reconstruction(sino_tv_gpu, theta_gpu, lam=0.01, n_iter=30,
+                          output_size=N_GPU, cuda=True)
+    t_gpu = time.perf_counter() - t0
+    print("    GPU  TV : {:.3f} s  (speedup {:.1f}×)".format(
+        t_gpu, t_cpu / max(t_gpu, 1e-6)))
+
+else:
+    print("\nSkipping GPU demo (CuPy not available).")
+    print("Install CuPy matching your CUDA version, e.g.:")
+    print("  pip install cupy-cuda12x")


### PR DESCRIPTION
Adds methods for propagation-based / holotomographic X-ray nanotomography.
All new compute functions accept `cuda=True` (CuPy) with automatic CPU fallback.
Rebased onto current master (0.3.0); pure additions, no changes to existing modules.

## Phase retrieval (`toupy.restoration`)
- `tie_hom` — single-distance TIE-Hom (Paganin) for homogeneous objects.
- `ctf_retrieve` — CTF retrieval, unified for single-distance, batched, and
  multi-distance (holotomographic) inversion (`delta_beta` + list of distances).
  Fixed sign convention (`I−1 = −2 sin(χ) φ`).
- `iterative_phase_retrieval` — nonlinear retrieval inverting the exact Fresnel
  forward model (CG, analytic adjoint, FD-verified). Single/multi-distance,
  Tikhonov + total-variation regularisation. Accurate in the multi-fringe /
  higher-δ/β regime where TIE-Hom blurs.
- `suggest_holo_distances` — rule-based, gap-free multi-distance series.

## Ring artifact correction (`toupy.restoration`)
- `remove_rings_wavelet_fft`, `remove_rings_titarenko`, `remove_rings_stack`.

## TV reconstruction (`toupy.tomo`)
- `tv_reconstruction`, `chambolle_pock_tv` (Chambolle–Pock primal–dual).

## Examples (`tutorial/`)
- `example_phase_retrieval_tv_ring.py`
- `example_iterative_phase_retrieval.py`
- `example_iterative_phase_tomography.py` (+ CTF frequency-coverage diagnostic)

## Verification
- Adjoint gradients finite-difference verified (rel err ~1e-10).
- All three examples run; e.g. tomography RMSE TIE-Hom 0.33 → iterative 0.10 →
  holotomography 0.075 (clean reference 0.075).
- Full package imports and examples pass on top of current master.

See `CHANGELOG.md` for details.