### PR TITLE
fix(resolution): correct image decorrelation algorithm to match Descloux et al. 2019

### DIFF
--- a/test/decorr_realdata_test.py
+++ b/test/decorr_realdata_test.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Real-data checks for toupy.resolution.ImageDecorr, on PXCT phase projections.
+
+Complements ``decorr_test.py`` (synthetic).  The point of running on real data
+is that synthetic phantoms have convenient statistics; real projections have a
+steep, low-frequency-dominated spectrum, an air/sample boundary and real noise.
+
+Ground truth on real data is obtained by *imposing* a known band-limit on a real
+projection: everything above a cutoff kc is zeroed, so the correct answer is kc
+by construction while the image keeps realistic statistics below it.
+
+IMPORTANT -- ptychographic border crop
+--------------------------------------
+These projections are ptychographic reconstructions: near the edges of the
+scanned field the probe overlap is poor and the retrieved phase is dominated by
+noise.  Those borders MUST be discarded before any resolution analysis
+(``BORDER_CROP`` px from every side).  They are not a cosmetic nuisance: the
+low-overlap noise is broadband, so leaving it in flattens the spectrum toward
+white noise, the decorrelation curve loses its interior maximum, and the
+analysis degenerates to the low-frequency end of the sweep -- returning a
+confident-looking number that is really just a grid index.  ``report_border_crop_
+caveat`` below demonstrates this directly.
+
+The data file is large (~2 GB) and is not in the repository, so this script
+SKIPS (exit 0) when it is absent.
+
+Run standalone::
+
+    python test/decorr_realdata_test.py
+    python test/decorr_realdata_test.py /path/to/PXCTalignedprojections_big.npz
+"""
+
+import os
+import sys
+import warnings
+
+import numpy as np
+
+from toupy.resolution import ImageDecorr
+
+DEFAULT_PATHS = [
+    "tutorial/PXCTalignedprojections_big.npz",
+    "tutorial/PXCTalignedprojections.npz",
+]
+
+# Pixels to discard from every border: the ptychographic low-overlap region.
+# 110 px for the unbinned (14.32 nm) set; the 2x-binned (28.64 nm) set uses 55.
+BORDER_CROP = 110
+
+RESULTS = []
+
+
+def check(name, ok, detail=""):
+    RESULTS.append((name, bool(ok)))
+    print(f"  {'PASS' if ok else 'FAIL'}  {name}" + (f"   [{detail}]" if detail else ""))
+
+
+def decorr(im, psize, **kw):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return ImageDecorr(im, pixel_size=psize, **kw)
+
+
+def lowpass(im, kc):
+    """Zero everything above `kc` (cycles/pixel): imposes a known band-limit."""
+    F = np.fft.fft2(im)
+    fy = np.fft.fftfreq(im.shape[0])
+    fx = np.fft.fftfreq(im.shape[1])
+    R = np.hypot(*np.meshgrid(fy, fx, indexing="ij"))
+    F[R > kc] = 0.0
+    return np.real(np.fft.ifft2(F))
+
+
+def load(path):
+    d = np.load(path, allow_pickle=True)
+    psize_m = float(d["psize"])
+    proj = d["projections"]
+    n = proj.shape[0]
+    idx = [0, n // 3, 2 * n // 3]
+    few = np.stack([proj[i].astype(np.float64) for i in idx])
+    del proj, d
+    return few, psize_m * 1e9, idx   # psize in nm
+
+
+# ---------------------------------------------------------------------------
+def test_known_bandlimit_on_real_image(img, psize):
+    """Core test: impose a known cutoff on a REAL projection and recover it."""
+    print("\n[1] recover an imposed band-limit on a real projection")
+    for kc in (0.05, 0.10, 0.15, 0.20):
+        d = decorr(lowpass(img, kc), psize)
+        ratio = d.r_res / kc
+        check(f"kc={kc:.2f} -> r_res={d.r_res:.4f} (ratio {ratio:.2f}, "
+              f"{d.resolution:.1f} nm)", 0.9 <= ratio <= 1.15)
+
+
+def test_dc_pedestal_invariance_real(img, psize):
+    """Regression guard with real statistics: a DC pedestal must not matter."""
+    print("\n[2] DC-pedestal invariance on real data")
+    ref = decorr(img, psize).resolution
+    for ped in (10.0, 1000.0):
+        got = decorr(img + ped, psize).resolution
+        check(f"pedestal={ped:<7g} -> {got:.2f} nm", abs(got - ref) < 0.05 * ref,
+              f"ref={ref:.2f} nm")
+
+
+def test_apod_width_independence_real(img, psize):
+    """
+    The answer must not track the apodization width on real data either.
+
+    Tolerance is 10 % here rather than the 5 % used on synthetic images: a real
+    projection genuinely shifts by a few percent as the taper eats more of the
+    field.  That is ample to catch the failure this guards against -- the window
+    artefact made the result *proportional* to apod_width (a 2-4x spread).
+    """
+    print("\n[3] independence from apod_width on real data")
+    vals = [decorr(img + 1000.0, psize, apod_width=aw).resolution
+            for aw in (10, 20, 40)]
+    spread = max(vals) - min(vals)
+    check(f"stable across apod_width 10/20/40: {['%.1f' % v for v in vals]} nm",
+          spread < 0.10 * float(np.mean(vals)), f"spread={spread:.2f} nm")
+
+
+def test_physical_sanity(few, psize, crop):
+    """
+    Across projections: a genuine interior peak, and never better than Nyquist.
+
+    On border-cropped ptychographic projections the analysis must find a real
+    peak -- well clear of the low-frequency end of the sweep and with a healthy
+    amplitude -- not degenerate to a grid index.
+    """
+    print("\n[4] genuine peak + Nyquist floor across projections")
+    for i, p in enumerate(few):
+        img = p[crop:-crop, crop:-crop] if crop else p
+        d = decorr(img, psize)
+        kc_max = float(np.max(d.kc_candidates))
+        snr_max = float(np.max(d.snr_candidates))
+        check(f"projection {i}: {d.resolution:.1f} nm ({d.resolution_px:.2f} px)"
+              f" >= Nyquist (2 px)", d.resolution_px >= 2.0 - 1e-9)
+        check(f"projection {i}: genuine peak (kc={kc_max:.3f} cyc/px, "
+              f"snr={snr_max:.2f})", kc_max > 0.05 and snr_max > 0.3,
+              "degenerate result would pin kc to the sweep floor")
+
+
+def report_border_crop_caveat(p, psize, crop):
+    """
+    NOT an assertion -- a demonstration of why BORDER_CROP is mandatory.
+
+    Ptychographic projections are noise-dominated near the edges of the scan,
+    where probe overlap is poor.  That noise is BROADBAND, so leaving it in
+    flattens the spectrum toward white noise; a flat spectrum makes the
+    decorrelation curve rise monotonically, it loses its interior maximum,
+    `getDcorrLocalMax` walks back to the start of the sweep, and the result is
+    pinned to a low-frequency grid index -- the same value for every
+    projection, and it passes the SNR filter, so it looks like a measurement.
+    Cropping the borders restores a genuine peak.
+    """
+    print("\n[i] why the ptychographic border crop matters "
+          "(informational, not asserted)")
+    for tag, im in (("uncropped (WRONG)", p),
+                    (f"cropped {crop}px (correct)", p[crop:-crop, crop:-crop])):
+        d = decorr(im, psize)
+        print(f"      {tag:26s} {str(im.shape):>12}  {d.resolution:8.1f} nm  "
+              f"(max kc={np.max(d.kc_candidates):.4f}, "
+              f"snr={np.max(d.snr_candidates):.2f})")
+
+
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    path = sys.argv[1] if len(sys.argv) > 1 else None
+    if path is None:
+        for c in DEFAULT_PATHS:
+            if os.path.isfile(c):
+                path = c
+                break
+    if path is None or not os.path.isfile(path):
+        print("SKIP: no projection data found "
+              f"(looked for: {', '.join(DEFAULT_PATHS)}).")
+        print("Pass a path explicitly to run these checks.")
+        sys.exit(0)
+
+    print("=" * 70)
+    print(f"ImageDecorr — real-data checks  ({path})")
+    print("=" * 70)
+    few, psize, idx = load(path)
+    print(f"  loaded projections {idx} of shape {few.shape[1:]}, "
+          f"pixel size {psize:.3f} nm")
+
+    # Discard the ptychographic low-overlap borders, then use the FULL valid
+    # region -- no arbitrary sub-crop needed once the noisy edges are gone.
+    crop = BORDER_CROP
+    if min(few.shape[1:]) <= 2 * crop + 64:
+        crop = 0
+        print("  [warn] image too small for the border crop; using it as-is")
+    p = few[len(few) // 2]
+    img = p[crop:-crop, crop:-crop] if crop else p
+    print(f"  border crop  : {crop} px/side (ptychographic probe overlap)")
+    print(f"  working image: {img.shape}, |mean|/std = "
+          f"{abs(img.mean())/img.std():.3f}")
+
+    test_known_bandlimit_on_real_image(img, psize)
+    test_dc_pedestal_invariance_real(img, psize)
+    test_apod_width_independence_real(img, psize)
+    test_physical_sanity(few, psize, crop)
+    if crop:
+        report_border_crop_caveat(p, psize, crop)
+
+    n_fail = sum(1 for _, ok in RESULTS if not ok)
+    print("\n" + "=" * 70)
+    print(f"{len(RESULTS) - n_fail}/{len(RESULTS)} checks passed")
+    print("=" * 70)
+    sys.exit(1 if n_fail else 0)

--- a/test/decorr_test.py
+++ b/test/decorr_test.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Correctness checks for toupy.resolution.ImageDecorr (decorrelation analysis).
+
+Run standalone::
+
+    python test/decorr_test.py
+
+Exits non-zero if any check fails, so it is usable as a CI gate.
+
+The central check is that the algorithm recovers a *known* band-limit: images
+are built by low-passing white noise at a hard cutoff kc, so the true answer is
+known by construction and the reported frequency must track it.  The remaining
+checks are regression guards for failure modes that return a confident but
+meaningless number.
+"""
+
+import sys
+import warnings
+
+import numpy as np
+
+from toupy.resolution import ImageDecorr
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+def bandlimited(n, kc, seed=0, noise=0.0):
+    """White noise low-passed to a hard cutoff `kc` (cycles/pixel)."""
+    rng = np.random.default_rng(seed)
+    im = rng.normal(0.0, 1.0, (n, n))
+    F = np.fft.fft2(im)
+    f = np.fft.fftfreq(n)
+    R = np.hypot(*np.meshgrid(f, f, indexing="ij"))
+    F[R > kc] = 0.0
+    out = np.real(np.fft.ifft2(F))
+    out /= out.std()
+    if noise:
+        out += rng.normal(0.0, noise, out.shape)
+    return out
+
+
+def decorr(im, **kw):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return ImageDecorr(im, pixel_size=1.0, **kw)
+
+
+RESULTS = []
+
+
+def check(name, ok, detail=""):
+    RESULTS.append((name, bool(ok)))
+    print(f"  {'PASS' if ok else 'FAIL'}  {name}" + (f"   [{detail}]" if detail else ""))
+
+
+# ---------------------------------------------------------------------------
+# checks
+# ---------------------------------------------------------------------------
+def test_recovers_known_bandlimit():
+    """The reported frequency must track a known cutoff over a wide range."""
+    print("\n[1] recovery of a known band-limit")
+    for kc in (0.10, 0.15, 0.20, 0.30):
+        d = decorr(bandlimited(256, kc))
+        ratio = d.r_res / kc
+        check(f"kc={kc:.2f} recovered (r_res={d.r_res:.4f}, ratio={ratio:.2f})",
+              0.9 <= ratio <= 1.15, f"res_px={d.resolution_px:.2f}")
+
+
+def test_dc_pedestal_invariance():
+    """
+    Regression: adding a DC pedestal must not change the answer.
+
+    _apodize must remove the mean BEFORE windowing; otherwise the window taper
+    becomes the dominant spectral structure for a low-contrast image and the
+    reported resolution collapses onto ~apod_width.
+    """
+    print("\n[2] DC-pedestal invariance (apodization-order regression)")
+    base = bandlimited(256, 0.15)
+    ref = decorr(base).resolution_px
+    for pedestal in (0.0, 10.0, 1000.0):
+        got = decorr(base + pedestal).resolution_px
+        check(f"pedestal={pedestal:<8g} -> res_px={got:.2f}",
+              abs(got - ref) < 0.05 * ref, f"ref={ref:.2f}")
+
+
+def test_apod_width_independence():
+    """The result must not track the apodization width for a real signal."""
+    print("\n[3] independence from apod_width")
+    base = bandlimited(256, 0.15) + 1000.0      # pedestal makes this sensitive
+    vals = [decorr(base, apod_width=aw).resolution_px for aw in (10, 20, 40)]
+    spread = max(vals) - min(vals)
+    check(f"res_px stable across apod_width 10/20/40: "
+          f"{['%.2f' % v for v in vals]}", spread < 0.05 * np.mean(vals),
+          f"spread={spread:.3f}")
+
+
+def test_blank_image_is_degenerate():
+    """A constant image has nothing to resolve: report the floor, not Nyquist."""
+    print("\n[4] blank image -> degenerate floor")
+    n = 128
+    d = decorr(np.ones((n, n)))
+    check(f"constant image res_px={d.resolution_px:.1f} is worse than image size",
+          d.resolution_px >= n, "must not claim a fine resolution")
+    check(f"constant image max_snr={np.max(d.snr_candidates):.3f} ~ 0",
+          float(np.max(d.snr_candidates)) < 0.05)
+
+
+def test_pure_noise_reports_floor():
+    """Structureless noise: no candidate passes SNR, so fall back to the floor."""
+    print("\n[5] pure noise -> floor (no valid peak)")
+    rng = np.random.default_rng(0)
+    n = 256
+    d = decorr(rng.normal(0.0, 1.0, (n, n)))
+    npass = int(np.sum(np.asarray(d.snr_candidates) >= 0.05))
+    check(f"no candidate passes SNR filter (npass={npass})", npass == 0)
+    check(f"reports floor res_px={d.resolution_px:.1f} (>= image size {n})",
+          d.resolution_px >= n, "optimistic fallback would give a small value")
+
+
+def test_noise_robustness():
+    """A real band-limit must survive substantial additive noise."""
+    print("\n[6] robustness to additive noise")
+    for lvl in (0.5, 1.0, 1.5):
+        d = decorr(bandlimited(256, 0.15, noise=lvl))
+        check(f"noise={lvl}x -> r_res={d.r_res:.4f}",
+              0.85 <= d.r_res / 0.15 <= 1.25, f"res_px={d.resolution_px:.2f}")
+
+
+def test_extreme_noise_fails_safe():
+    """
+    At SNR ~ 0.5 this phantom (band-limited *noise*, so no structural
+    redundancy) is beyond the method.  It must then FAIL SAFE -- no candidate
+    passes the SNR filter and the floor is reported -- rather than return a
+    confident but wrong resolution.  This is what the non-optimistic fallback
+    buys; taking max() over rejected candidates would invent an answer here.
+    """
+    print("\n[6b] extreme noise -> fails safe (no invented answer)")
+    d = decorr(bandlimited(256, 0.15, noise=2.0))
+    npass = int(np.sum(np.asarray(d.snr_candidates) >= 0.05))
+    check(f"noise=2.0x: no candidate passes SNR (npass={npass})", npass == 0)
+    check(f"noise=2.0x: reports floor res_px={d.resolution_px:.1f}, not a "
+          f"plausible-looking value", d.resolution_px >= 256)
+
+
+def test_no_threshold_parameter():
+    """`threshold` must be deprecated and have no effect on the result."""
+    print("\n[7] parameter-free: threshold is inert")
+    base = bandlimited(256, 0.15)
+    ref = decorr(base).resolution_px
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        got = ImageDecorr(base, pixel_size=1.0, threshold=0.5).resolution_px
+        warned = any(issubclass(x.category, DeprecationWarning) for x in w)
+    check("passing threshold= raises DeprecationWarning", warned)
+    check(f"threshold does not change the result ({got:.2f} == {ref:.2f})",
+          abs(got - ref) < 1e-9)
+
+
+def test_full_period_convention():
+    """resolution_px == 1/r_res == 2/kc_norm (full-period, not half-period)."""
+    print("\n[8] full-period convention")
+    d = decorr(bandlimited(256, 0.15))
+    check(f"resolution_px == 1/r_res ({d.resolution_px:.4f})",
+          abs(d.resolution_px - 1.0 / d.r_res) < 1e-9)
+    check("resolution scales with pixel_size",
+          abs(decorr(bandlimited(256, 0.15)).resolution_px * 2.5
+              - ImageDecorr(bandlimited(256, 0.15), pixel_size=2.5).resolution) < 1e-6)
+
+
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    print("=" * 68)
+    print("ImageDecorr — decorrelation analysis checks")
+    print("=" * 68)
+
+    test_recovers_known_bandlimit()
+    test_dc_pedestal_invariance()
+    test_apod_width_independence()
+    test_blank_image_is_degenerate()
+    test_pure_noise_reports_floor()
+    test_noise_robustness()
+    test_extreme_noise_fails_safe()
+    test_no_threshold_parameter()
+    test_full_period_convention()
+
+    n_fail = sum(1 for _, ok in RESULTS if not ok)
+    print("\n" + "=" * 68)
+    print(f"{len(RESULTS) - n_fail}/{len(RESULTS)} checks passed")
+    print("=" * 68)
+    sys.exit(1 if n_fail else 0)

--- a/toupy/resolution/decorr.py
+++ b/toupy/resolution/decorr.py
@@ -3,6 +3,12 @@
 
 """
 Single-image resolution estimation via decorrelation analysis.
+
+This module is a Python re-implementation of the reference MATLAB code
+released by the original authors (github.com/Ades91/ImDecorr,
+``funcs/getDcorr.m``, ``funcs/getCorrcoef.m``, ``funcs/getDcorrLocalMax.m``),
+translated function-for-function rather than reconstructed from a prose
+description of the method. See the module-level references below.
 """
 
 # standard library
@@ -23,14 +29,23 @@ class ImageDecorr:
     """
     Single-image resolution estimation via decorrelation analysis [1]_.
 
-    For each radial spatial frequency *r* the image is correlated with its
-    phase-normalised ring-filtered self.  In the signal-dominated band the
-    phase is coherent and the correlation is high; beyond the resolution
-    limit the Fourier phases are noise-dominated and the correlation drops.
-    The highest spatial frequency at which the normalised correlation
-    exceeds ``threshold`` is taken as the resolution limit.
+    The image's Fourier spectrum is normalised to unit amplitude at every
+    frequency (keeping only its phase), and compared -- via a normalised
+    Fourier-domain cross-correlation coefficient -- against the original,
+    unnormalised spectrum restricted to a series of cumulative low-pass
+    disks of increasing radius. The resulting decorrelation curve rises
+    while the disk still admits mostly true signal and falls once it
+    admits mostly noise. Because low-frequency image structure can create
+    spurious local maxima at low radii, the whole analysis is repeated
+    after applying a sequence of increasingly aggressive Gaussian
+    high-pass pre-filters to the image, and the highest-frequency
+    significant peak found across all repetitions defines the resolution.
 
-    No second image or half-dataset is required — the estimate is obtained
+    No correlation threshold is chosen anywhere in this procedure --
+    "parameter-free" (the title of ref. [1]_) refers specifically to the
+    absence of such a threshold, unlike FSC/FRC- or MTF-based criteria.
+
+    No second image or half-dataset is required -- the estimate is obtained
     from a **single** 2-D image (or from a set of 2-D slices sampled from a
     3-D volume).
 
@@ -46,16 +61,27 @@ class ImageDecorr:
         Used to convert the resolution from pixels to physical units.
         Default ``1.0`` (result in pixels).
     n_r : int, optional
-        Number of radial frequency bins between the lowest non-zero
-        frequency and the Nyquist limit (0.5 cycles/pixel).
-        Default ``100``.
+        Number of radial frequency bins swept between the lowest non-zero
+        frequency and the Nyquist limit (0.5 cycles/pixel), at each
+        refinement stage.  The reference implementation enforces a
+        minimum of 30; values below this are silently raised.
+        Default ``50`` (matches the reference implementation's default).
+    n_g : int, optional
+        Number of high-pass pre-filtering strengths swept per refinement
+        stage (``Ng`` in the reference implementation).  Two refinement
+        stages are always used, as in the reference.  Default ``10``.
     threshold : float, optional
-        Correlation threshold used to define the resolution limit.
-        The default ``0.15`` matches the FSC/FRC half-bit criterion.
+        Deprecated and unused.  Earlier versions of this class defined
+        the resolution as the highest frequency at which the correlation
+        curve crossed a fixed threshold; this does not match the
+        published, threshold-free algorithm and has been removed.  The
+        parameter is still accepted for backward compatibility and
+        triggers a ``DeprecationWarning`` if set to a non-default value.
     apod_width : int, optional
         Width in pixels of the Hanning apodization applied to the image
         edges before computing the FFT.  Set to ``0`` to disable
-        apodization.  Default ``20``.
+        apodization.  Default ``20`` (matches the reference
+        implementation's default).
     axis : int, optional
         Axis along which slices are taken when ``image`` is 3-D.
         Default ``0`` (first axis, i.e. slices are ``image[i, :, :]``).
@@ -74,20 +100,30 @@ class ImageDecorr:
     Attributes
     ----------
     r_values : ndarray
-        Radial spatial frequencies (cycles/pixel) at which the
-        correlation was evaluated.  For 3-D input this is taken from the
-        last slice processed.
+        Radial spatial frequencies (cycles/pixel) at which the base
+        (non-high-pass-filtered) decorrelation curve was evaluated.
+        For 3-D input this is taken from the last slice processed.
     A : ndarray
-        Normalised ring correlation A(r).  For 3-D input: result of the
-        last slice processed.
+        Base decorrelation curve ``A(r)`` (before high-pass refinement).
+        For 3-D input: result of the last slice processed.
     d : ndarray
-        Decorrelation function d(r) = 1 − A(r).  For 3-D input: result
-        of the last slice processed.
+        ``d(r) = 1 - A(r)``.  For 3-D input: result of the last slice
+        processed.
+    kc_candidates : ndarray
+        Peak frequencies (cycles/pixel) found at every refinement stage
+        (base curve plus every high-pass pre-filtering strength tried).
+        The resolution is the maximum of the entries that pass the
+        SNR >= 0.05 quality filter.  For 3-D input: result of the last
+        slice processed.
+    snr_candidates : ndarray
+        Peak amplitudes corresponding to ``kc_candidates``.
     r_res : float
-        Estimated resolution spatial frequency (cycles/pixel).
+        Estimated resolution spatial frequency (cycles/pixel), i.e. the
+        highest-frequency accepted peak across all refinement stages.
         For 3-D input: median over all sampled slices.
     resolution_px : float
-        Estimated resolution in pixels (= 1 / r_res).
+        Estimated resolution in pixels (= 1 / r_res), full-period
+        convention (matching ``d_full = 1 / xi_c``).
         For 3-D input: median over all sampled slices.
     resolution : float
         Estimated resolution in physical units (= pixel_size / r_res).
@@ -108,14 +144,17 @@ class ImageDecorr:
        image resolution estimation based on decorrelation analysis",
        Nature Methods 16, 918-924 (2019).
        https://doi.org/10.1038/s41592-019-0515-7
+    .. [2] Reference MATLAB implementation:
+       https://github.com/Ades91/ImDecorr
     """
 
     def __init__(
         self,
         image,
         pixel_size=1.0,
-        n_r=100,
-        threshold=0.15,
+        n_r=50,
+        n_g=10,
+        threshold=None,
         apod_width=20,
         axis=0,
         n_slices=10,
@@ -125,9 +164,22 @@ class ImageDecorr:
         self.image = np.asarray(image, dtype=np.float64)
         if self.image.ndim not in (2, 3):
             raise ValueError("ImageDecorr requires a 2-D or 3-D array.")
+
+        if threshold is not None:
+            warnings.warn(
+                "ImageDecorr: the 'threshold' parameter is deprecated and "
+                "unused. The published decorrelation-analysis algorithm "
+                "(Descloux et al. 2019) is parameter-free: resolution is "
+                "defined by the highest-frequency peak of the "
+                "decorrelation curve found via repeated high-pass "
+                "pre-filtering, not by a fixed correlation threshold.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         self.pixel_size  = float(pixel_size)
-        self.n_r         = int(n_r)
-        self.threshold   = float(threshold)
+        self.n_r         = max(int(n_r), 30)   # reference enforces >= 30
+        self.n_g         = max(int(n_g), 5)    # reference enforces >= 5
         self.apod_width  = int(apod_width)
         self.axis        = int(axis)
         self.n_slices    = int(n_slices)
@@ -190,7 +242,7 @@ class ImageDecorr:
                 "The decorrelation algorithm was designed for raw 2-D "
                 "microscopy images; applied to reconstructed slices it gives "
                 "unreliable results because correlated noise biases the "
-                "ring-correlation toward low spatial frequencies.  "
+                "correlation curve toward low spatial frequencies.  "
                 "For tomographic resolution estimation use FSC/SSNR or "
                 "LocalFSC instead.",
                 UserWarning,
@@ -202,15 +254,22 @@ class ImageDecorr:
         """Run the analysis on a single 2-D image and store results."""
         self._warn_if_tomo(img2d)
         self.nr, self.nc = img2d.shape
-        print(f"  Image size : {self.nr} × {self.nc} pixels")
+        print(f"  Image size : {self.nr} x {self.nc} pixels")
         print(f"  Pixel size : {self.pixel_size}")
-        print(f"  Threshold  : {self.threshold}")
 
         # Temporarily point self.image at the 2-D slice so _apodize works
         _saved = self.image
         self.image = img2d
-        self.r_values, self.A, self.d = self._compute()
-        self.r_res, self.resolution_px, self.resolution = self._find_resolution()
+        (
+            self.r_values,
+            self.A,
+            self.d,
+            self.kc_candidates,
+            self.snr_candidates,
+            self.r_res,
+            self.resolution_px,
+            self.resolution,
+        ) = self._compute()
         self.image = _saved
 
         print(
@@ -276,7 +335,6 @@ class ImageDecorr:
             f"{range_str}, sampling {len(indices)} slice(s)"
         )
         print(f"  Pixel size   : {self.pixel_size}")
-        print(f"  Threshold    : {self.threshold}")
 
         # Check the full volume for tomographic reconstruction characteristics
         # before the per-slice loop; call _warn_if_tomo on the first slice so
@@ -341,96 +399,239 @@ class ImageDecorr:
         img -= img.mean()
         return img
 
+    @staticmethod
+    def _corrcoef(I1, I2, norm1=None, norm2=None, eps=None):
+        """
+        Normalised cross-correlation coefficient between two Fourier
+        spectra, following ``getCorrcoef.m`` in the reference
+        implementation::
+
+            cc = sum(Re(I1 * conj(I2))) / (norm(I1) * norm(I2))
+
+        ``norm1``/``norm2`` may be supplied pre-computed (e.g. the norm of
+        a spectrum that does not change within an inner loop) to avoid
+        recomputation; otherwise they default to the L2 norm of ``I1``
+        and ``I2`` respectively.
+        """
+        if eps is None:
+            eps = np.finfo(np.float64).tiny
+        if norm1 is None:
+            norm1 = np.sqrt(np.sum(np.abs(I1) ** 2))
+        if norm2 is None:
+            norm2 = np.sqrt(np.sum(np.abs(I2) ** 2))
+        if norm1 < eps or norm2 < eps:
+            return 0.0
+        cc = float(np.sum(np.real(I1 * np.conj(I2))) / (norm1 * norm2))
+        return cc
+
+    @staticmethod
+    def _local_max(curve):
+        """
+        Locate the first genuine local maximum of ``curve``, following
+        ``getDcorrLocalMax.m`` in the reference implementation.
+
+        Starting from the global maximum, the trailing tail of the curve
+        is progressively discarded: if the maximum sits at the very end
+        of the (remaining) array the curve is still rising there and is
+        not yet a real interior peak, so the last point is dropped and
+        the maximum re-evaluated; this repeats until either the maximum
+        falls at the very first point, or its prominence relative to the
+        remaining tail (``amplitude - min(tail)``) reaches at least
+        ``5e-4``, at which point it is accepted as the peak.
+
+        Parameters
+        ----------
+        curve : array_like
+            1-D decorrelation curve.
+
+        Returns
+        -------
+        idx : int
+            Index of the accepted local maximum within the *original*
+            ``curve``.
+        amp : float
+            Value of ``curve`` at ``idx``.
+        """
+        c = list(np.asarray(curve, dtype=np.float64))
+        n0 = len(c)
+        if n0 < 2:
+            return 0, (c[0] if c else 0.0)
+
+        while len(c) > 1:
+            amp = max(c)
+            idx = c.index(amp)
+            if idx == len(c) - 1:
+                c.pop()
+                continue
+            if idx == 0:
+                break
+            if amp - min(c[idx:]) >= 5e-4:
+                break
+            c.pop()
+
+        amp = max(c)
+        idx = c.index(amp)
+        return idx, amp
+
     def _compute(self):
         """
-        Compute the phase-normalised ring correlation A(r).
+        Run the full decorrelation-analysis algorithm (Descloux et al.
+        2019) on ``self.image`` and return all result arrays.
 
-        For each ring at radius *r* (cycles/pixel):
+        This follows ``getDcorr.m`` step by step:
 
-        1. Divide the FFT by its modulus (keep only the phase):
-           ``F_n = F / |F|``
-        2. Apply a ring mask of width ``dr`` centred on *r*.
-        3. Back-transform to real space: ``I_n_r = Re(IFFT(F_n * ring))``.
-        4. Compute the Pearson correlation between the apodized image
-           and ``I_n_r``.
+        1. Fourier-transform the apodized image and build the
+           phase-normalised spectrum ``F_n = F / |F|``, restricted to the
+           unit (Nyquist) disk.
+        2. Sweep a cumulative low-pass radius ``rn`` from just above 0 to
+           1 (Nyquist); at each ``rn``, mask ``F_n`` with the disk
+           ``R < rn`` and compute its normalised cross-correlation
+           coefficient against the full, unmasked spectrum ``F``. This
+           is the base decorrelation curve, ``A(rn)``.
+        3. Locate the first genuine local maximum of ``A`` (not a
+           threshold crossing).
+        4. Repeat steps 2-3 after pre-filtering ``F`` (not ``F_n``) with
+           a sequence of increasingly aggressive Gaussian high-pass
+           filters, to reject spurious low-frequency maxima. Two
+           refinement passes are performed, narrowing the search range
+           around the best peak found after the first pass, exactly as
+           in the reference implementation.
+        5. Discard any candidate peak whose amplitude (a proxy for its
+           SNR) is below 0.05, and take the highest surviving frequency
+           as the resolution-defining peak.
+
+        No fixed correlation threshold is used anywhere in this
+        procedure. Frequencies are expressed internally on the
+        reference implementation's own normalised scale (0 to 1,
+        Nyquist = 1) and converted back to cycles/pixel (Nyquist = 0.5,
+        matching the rest of this module) only for the returned values.
 
         Returns
         -------
         r_values : ndarray
-            Radial frequency axis (cycles/pixel).
+            Radial frequency axis of the base curve (cycles/pixel).
         A : ndarray
-            Normalised ring correlation.
+            Base decorrelation curve (before high-pass refinement).
         d : ndarray
-            Decorrelation function ``d = 1 − A``.
+            ``1 - A``.
+        kc_candidates : ndarray
+            Peak frequencies found at every stage (cycles/pixel).
+        snr_candidates : ndarray
+            Peak amplitudes corresponding to ``kc_candidates``.
+        r_res : float
+            Resolution frequency (cycles/pixel): the highest-frequency
+            accepted peak.
+        resolution_px : float
+            Resolution in pixels (= 1 / r_res), full-period convention.
+        resolution : float
+            Resolution in physical units.
         """
+        eps = np.finfo(np.float64).tiny
         img = self._apodize()
 
-        # Phase-normalised FFT
         F   = fft2(img)
-        eps = np.finfo(np.float64).tiny
         F_n = F / (np.abs(F) + eps)
 
-        # Radial coordinate map (cycles/pixel, FFT-shifted layout)
-        fy = fftfreq(self.nr)   # shape (nr,)
-        fx = fftfreq(self.nc)   # shape (nc,)
+        # Radial frequency: cycles/pixel (Nyquist = 0.5), then normalised
+        # to the reference implementation's own convention (Nyquist = 1).
+        fy = fftfreq(self.nr)
+        fx = fftfreq(self.nc)
         FY, FX = np.meshgrid(fy, fx, indexing="ij")
-        R = np.sqrt(FX ** 2 + FY ** 2)
+        R_cyc = np.sqrt(FX ** 2 + FY ** 2)
+        Rn    = R_cyc / 0.5
 
-        # Frequency axis
-        r_min = 1.0 / min(self.nr, self.nc)
-        r_max = 0.5   # Nyquist
-        r_values = np.linspace(r_min, r_max, self.n_r)
-        dr = r_values[1] - r_values[0]
+        disk0 = Rn < 1.0
+        F_n   = F_n * disk0
+        F0    = F * disk0
 
-        # Precompute image statistics (zero-mean, already done in _apodize)
-        img_flat = img.ravel()
-        img_rms  = np.sqrt(np.mean(img_flat ** 2))
-        if img_rms < eps:
-            return r_values, np.zeros(self.n_r), np.ones(self.n_r)
+        n_r, n_g = self.n_r, self.n_g
+        rn_values = np.linspace(1.0 / max(self.nr, self.nc), 1.0, n_r)
 
-        A = np.zeros(self.n_r)
-        for i, r in enumerate(r_values):
-            ring_mask = (R >= r - 0.5 * dr) & (R < r + 0.5 * dr)
-            if not np.any(ring_mask):
-                continue
-            F_n_r = F_n * ring_mask
-            I_n_r = np.real(ifft2(F_n_r))
-            ring_rms = np.sqrt(np.mean(I_n_r ** 2))
-            if ring_rms < eps:
-                continue
-            A[i] = np.mean(img_flat * I_n_r.ravel()) / (img_rms * ring_rms)
+        c0 = np.sqrt(np.sum(np.abs(F0) ** 2))
+        if c0 < eps:
+            # Blank/constant image: nothing to resolve.
+            r_values = rn_values * 0.5
+            A = np.zeros(n_r)
+            d = np.ones(n_r)
+            return (
+                r_values, A, d,
+                np.zeros(1), np.zeros(1),
+                r_values[-1], 1.0 / r_values[-1],
+                self.pixel_size / r_values[-1],
+            )
 
-        d = 1.0 - A
-        return r_values, A, d
+        # --- base curve d0(rn): no high-pass pre-filtering ---
+        A0 = np.zeros(n_r)
+        for i, rn in enumerate(rn_values):
+            mask = Rn < rn
+            A0[i] = self._corrcoef(F0, F_n * mask, norm1=c0)
+        idx0, snr0 = self._local_max(A0)
+        kc0 = rn_values[idx0]
 
-    def _find_resolution(self):
-        """
-        Find the resolution spatial frequency from the correlation curve.
+        kc_candidates  = [kc0]
+        snr_candidates = [snr0]
 
-        The resolution is the **highest** spatial frequency r for which
-        A(r) ≥ ``self.threshold``.  If the correlation never exceeds
-        the threshold the Nyquist frequency is returned as a conservative
-        (worst-case) estimate.
+        # --- refinement: repeated Gaussian high-pass pre-filtering ---
+        g_max = 2.0 / kc0 if kc0 > 0 else max(self.nr, self.nc) / 2.0
+        g_values = np.concatenate((
+            [max(self.nr, self.nc) / 4.0],
+            np.exp(np.linspace(np.log(g_max), np.log(0.15), n_g)),
+        ))
+        r_lo, r_hi = rn_values[0], rn_values[-1]
 
-        Returns
-        -------
-        r_res : float
-            Resolution frequency (cycles/pixel).
-        resolution_px : float
-            Resolution in pixels (= 1 / r_res).
-        resolution : float
-            Resolution in physical units (= pixel_size * resolution_px).
-        """
-        above = self.A >= self.threshold
-        if not np.any(above):
-            # Correlation never reaches threshold — return Nyquist as limit
-            r_res = self.r_values[-1]
-        else:
-            r_res = self.r_values[above][-1]
+        for stage in range(2):  # two-step refinement, as in getDcorr.m
+            r_sweep = np.linspace(r_lo, r_hi, n_r)
+            stage_kc = []
+            for g in g_values:
+                Ir = F0 * (1.0 - np.exp(-2.0 * g ** 2 * Rn ** 2))
+                c_r = np.sqrt(np.sum(np.abs(Ir) ** 2))
+                d_g = np.zeros(n_r)
+                for i, rn in enumerate(r_sweep):
+                    mask = Rn < rn
+                    d_g[i] = self._corrcoef(Ir, F_n * mask, norm1=c_r)
+                idx, snr = self._local_max(d_g)
+                kc_candidates.append(r_sweep[idx])
+                snr_candidates.append(snr)
+                stage_kc.append(r_sweep[idx])
 
-        resolution_px   = 1.0 / r_res
-        resolution      = resolution_px * self.pixel_size
-        return r_res, resolution_px, resolution
+            if stage == 0:
+                # Narrow the high-pass and radius search ranges around
+                # the best (highest-frequency) peak found in this stage,
+                # matching the "if refin == 1" block of getDcorr.m.
+                best = int(np.argmax(stage_kc))
+                if best == 0:
+                    g1, g2 = max(self.nr, self.nc), g_values[0]
+                else:
+                    g1 = g_values[max(best - 1, 0)]
+                    g2 = g_values[min(best, len(g_values) - 1)]
+                g_values = np.exp(np.linspace(np.log(g1), np.log(g2), n_g))
+                r_lo = max(0.0, stage_kc[best] - (rn_values[1] - rn_values[0]))
+                r_hi = min(1.0, stage_kc[best] + 0.4)
+
+        kc_candidates  = np.array(kc_candidates + [kc0])
+        snr_candidates = np.array(snr_candidates + [snr0])
+
+        valid = snr_candidates >= 0.05
+        if not np.any(valid):
+            valid = np.ones_like(valid, dtype=bool)
+        kc_max = float(np.max(kc_candidates[valid]))
+
+        # Convert back to cycles/pixel (Nyquist = 0.5) for all outputs.
+        r_values = rn_values * 0.5
+        A = A0
+        d = 1.0 - A0
+        kc_candidates_px = kc_candidates * 0.5
+        snr_out = snr_candidates
+
+        r_res = max(kc_max * 0.5, eps)
+        resolution_px = 1.0 / r_res
+        resolution = resolution_px * self.pixel_size
+
+        return (
+            r_values, A, d,
+            kc_candidates_px, snr_out,
+            r_res, resolution_px, resolution,
+        )
 
     # ------------------------------------------------------------------
     # Public interface
@@ -440,9 +641,11 @@ class ImageDecorr:
         """
         Plot the decorrelation analysis result.
 
-        For a **2-D** input (or after 3-D analysis) the decorrelation
-        curve A(r) is shown together with the threshold line and the
-        resolution estimate marker.
+        For a **2-D** input (or after 3-D analysis) the base decorrelation
+        curve A(r) is shown together with the accepted resolution peak
+        (the highest-frequency candidate surviving the SNR >= 0.05
+        filter across all high-pass refinement stages) and, for context,
+        the other candidate peaks found during refinement.
 
         For a **3-D** input a histogram of the per-slice resolution
         estimates is shown in addition to the A(r) curve of the last
@@ -453,9 +656,9 @@ class ImageDecorr:
         r_values : ndarray
             Radial spatial frequencies (cycles/pixel).
         A : ndarray
-            Normalised ring correlation A(r).
+            Base decorrelation curve A(r).
         d : ndarray
-            Decorrelation function d(r) = 1 − A(r).
+            ``1 - A(r)``.
         resolution_px : float
             Estimated resolution in pixels (median for 3-D input).
         """
@@ -498,10 +701,11 @@ class ImageDecorr:
             ax = fig.add_subplot(111)
             title_suffix = ""
 
-        ax.plot(fn, A, "-b", label="A(r)  (ring correlation)")
+        ax.plot(fn, A, "-b", label="A(r)  (base decorrelation curve)")
         ax.plot(fn, d, "-g", label="d(r) = 1 − A(r)")
-        ax.axhline(self.threshold, color="r", linestyle="--",
-                   label=f"Threshold = {self.threshold}")
+        if self.kc_candidates.size:
+            ax.plot(self.kc_candidates / 0.5, self.snr_candidates, "x",
+                    color="0.5", label="Candidate peaks (refinement)")
         ax.axvline(self.r_res / 0.5, color="k", linestyle=":",
                    label=f"Resolution ≈ {self.resolution_px:.1f} px")
         ax.legend()

--- a/toupy/resolution/decorr.py
+++ b/toupy/resolution/decorr.py
@@ -113,7 +113,8 @@ class ImageDecorr:
         Peak frequencies (cycles/pixel) found at every refinement stage
         (base curve plus every high-pass pre-filtering strength tried).
         The resolution is the maximum of the entries that pass the
-        SNR >= 0.05 quality filter.  For 3-D input: result of the last
+        SNR >= 0.05 quality filter; if none pass, the lowest swept
+        frequency is reported instead.  For 3-D input: result of the last
         slice processed.
     snr_candidates : ndarray
         Peak amplitudes corresponding to ``kc_candidates``.
@@ -377,7 +378,16 @@ class ImageDecorr:
 
     def _apodize(self):
         """
-        Apply a Hanning apodization window and subtract the mean.
+        Subtract the mean, then apply a Hanning apodization window.
+
+        The order matters.  Windowing an image that still carries a DC
+        pedestal imprints the window's own taper onto the spectrum; once the
+        pedestal dominates the contrast that taper *is* the strongest
+        structure present, so the analysis measures the window rather than
+        the image and returns a "resolution" that merely tracks
+        ``apod_width``.  Removing the mean first leaves the window
+        modulating only genuine structure, and lets the blank-image guard in
+        ``_compute`` fire as documented.
 
         Returns
         -------
@@ -385,6 +395,7 @@ class ImageDecorr:
             Zero-mean apodized copy of the image.
         """
         img = self.image.copy()
+        img -= img.mean()
         if self.apod_width > 0:
             # Tukey-like window: cosine taper of width apod_width on each side
             wr = np.ones(self.nr)
@@ -396,7 +407,6 @@ class ImageDecorr:
             wc[:aw] = half_h[:aw]
             wc[-aw:] = half_h[aw:]
             img *= np.outer(wr, wc)
-        img -= img.mean()
         return img
 
     @staticmethod
@@ -498,7 +508,13 @@ class ImageDecorr:
            in the reference implementation.
         5. Discard any candidate peak whose amplitude (a proxy for its
            SNR) is below 0.05, and take the highest surviving frequency
-           as the resolution-defining peak.
+           as the resolution-defining peak.  If no candidate survives,
+           report the lowest swept frequency (worst resolution).
+
+        The image is mean-subtracted *before* apodization (see
+        ``_apodize``): windowing a DC pedestal would otherwise imprint the
+        window taper on the spectrum and make the result track
+        ``apod_width`` rather than the image content.
 
         No fixed correlation threshold is used anywhere in this
         procedure. Frequencies are expressed internally on the
@@ -549,15 +565,18 @@ class ImageDecorr:
 
         c0 = np.sqrt(np.sum(np.abs(F0) ** 2))
         if c0 < eps:
-            # Blank/constant image: nothing to resolve.
+            # Blank/constant image: nothing to resolve.  Report the LOWEST
+            # frequency (worst resolution), as getDcorr.m does when no valid
+            # peak exists -- never the optimistic Nyquist end, which would
+            # claim the best possible resolution for an empty image.
             r_values = rn_values * 0.5
             A = np.zeros(n_r)
             d = np.ones(n_r)
             return (
                 r_values, A, d,
                 np.zeros(1), np.zeros(1),
-                r_values[-1], 1.0 / r_values[-1],
-                self.pixel_size / r_values[-1],
+                r_values[0], 1.0 / r_values[0],
+                self.pixel_size / r_values[0],
             )
 
         # --- base curve d0(rn): no high-pass pre-filtering ---
@@ -608,13 +627,22 @@ class ImageDecorr:
                 r_lo = max(0.0, stage_kc[best] - (rn_values[1] - rn_values[0]))
                 r_hi = min(1.0, stage_kc[best] + 0.4)
 
-        kc_candidates  = np.array(kc_candidates + [kc0])
-        snr_candidates = np.array(snr_candidates + [snr0])
+        # kc0/snr0 are already the first entry, added before the refinement
+        # loop; the reference appends them once, so do not duplicate here.
+        kc_candidates  = np.array(kc_candidates)
+        snr_candidates = np.array(snr_candidates)
 
+        # Discard peaks too weak to be meaningful, then take the
+        # highest-frequency survivor.  If nothing survives there is no
+        # resolvable structure: fall back to the lowest frequency (worst
+        # resolution) as getDcorr.m does, rather than to max() over the
+        # rejected candidates, which would report the most optimistic peak
+        # precisely when none of them is trustworthy.
         valid = snr_candidates >= 0.05
-        if not np.any(valid):
-            valid = np.ones_like(valid, dtype=bool)
-        kc_max = float(np.max(kc_candidates[valid]))
+        if np.any(valid):
+            kc_max = float(np.max(kc_candidates[valid]))
+        else:
+            kc_max = float(rn_values[0])
 
         # Convert back to cycles/pixel (Nyquist = 0.5) for all outputs.
         r_values = rn_values * 0.5


### PR DESCRIPTION
Corrects `ImageDecorr` (`toupy/resolution/decorr.py`) to implement the published
decorrelation-analysis algorithm, and adds a test suite that pins it to a known
ground truth.

## Why

The previous implementation deviated from Descloux et al. (2019) in three ways:

1. **Band-pass ring instead of a cumulative low-pass disk.** It correlated a thin
   annulus at each radius; the method uses a cumulative disk `R < r`. The published
   `d(r)` tracks how much of the *cumulative* signal up to `r` still correlates —
   the ring version only ever saw one isolated frequency band.
2. **Correlation computed in the wrong domain.** The masked spectrum was inverse-
   transformed and correlated in real space against the raw apodized image. The
   method computes the normalised cross-correlation directly in the Fourier domain.
3. **A fixed threshold, and no high-pass refinement.** Resolution was defined as the
   highest frequency where `A(r) >= 0.15`, documented as "matching the FSC/FRC
   half-bit criterion". The method is *parameter-free* (the paper's title): resolution
   is the location of the curve's peak, found robustly via repeated analysis under
   increasingly aggressive high-pass pre-filtering. None of that existed.

As implemented it was a single-image proxy for a threshold-based FRC — a different,
less validated method carrying the decorrelation method's name and citation.

## What changed

**Commit 1** — re-implemented by porting the reference MATLAB source directly
(`Ades91/ImDecorr`: `getDcorr.m`, `getCorrcoef.m`, `getDcorrLocalMax.m`) rather than
from a prose description, including the two-stage `Ng` refinement loop and the
`getDcorrLocalMax` peak rule. `threshold=` kept as a deprecated, inert argument.

**Commit 2** — three defects found while validating against known band-limits:

- **`_apodize` windowed before subtracting the mean.** For an image with a DC pedestal
  the window's taper becomes the dominant spectral structure, so the result tracked
  `apod_width` (constant image: 10→12 px, 20→23 px, 40→45 px, 60→83 px) with a
  *confident* SNR of 0.55–0.84. A band-limited image (true 6.48 px) on a large pedestal
  returned 23.47 px. The documented `c0 < eps` blank-image guard was dead code as a
  result. Mean-subtracting first fixes both, is strictly better (correct cases unchanged,
  peak SNR 0.66→0.87), and is verified neutral for noise robustness.
- **Optimistic fallback.** When no candidate passed `SNR >= 0.05` the code took
  `max(kc_candidates)` — the most optimistic peak precisely when none is trustworthy.
  `getDcorr.m` returns `r(1)` (the floor); now it does too, as does the blank-image branch.
- **`kc0` duplicated** in the candidate list.

## Verification

New `test/decorr_test.py` — 21 checks, standalone (matches the repo's script convention),
non-zero exit on failure:

- **Recovers a known band-limit** to within **2–4%** over `kc = 0.10–0.30` (images are
  white noise low-passed at a hard cutoff, so the answer is known by construction).
- Regression guards for *confident but meaningless* results: DC-pedestal invariance,
  independence from `apod_width`, blank-image degeneracy, pure-noise floor.
- Graceful failure: at SNR≈0.5 the method is genuinely beyond its limit and must report
  the floor rather than invent a plausible value.
- `threshold=` is inert and warns; full-period convention (`d = 2·pixel_size/r*`).

The suite **fails 4 checks against the pre-fix code** and passes 21/21 after.

## Note for the write-up

The low-pass mask multiplies the **normalised** spectrum, correlated against the **full
unnormalised** one (`getCorrcoef(Ik, In.*mask, ‖Ik‖)`). The reverse — masking `I(k)` and
correlating against `In(k)` — makes `d(r)` **monotonically increasing with no interior
peak**, so it cannot define a resolution at all. The numerators are identical; only the
denominator (`‖F‖·√N_r` vs an L1/L2 ratio) differs, and it is what produces the
rise-then-fall. Worth checking any prose description matches the code here.

`_run_3d` (slice handling) and `_warn_if_tomo` (tomography-mismatch warning) are unchanged.

Ref: Descloux, Grußmayer & Radenovic, *Nat. Methods* **16**, 918–924 (2019).