### PR TITLE
feat(tomo): two-pass multislice reconstruction (multislice engine + TwoPassReconstructor)

### DIFF
--- a/toupy/tomo/__init__.py
+++ b/toupy/tomo/__init__.py
@@ -9,3 +9,9 @@ from .geometry import *
 from .fdk import *
 from .cone_projector import *
 from .tv_recons import *
+from .multislice import *
+from .twopass import *
+try:
+    from .multislice_torch import *
+except ImportError:
+    pass   # torch not installed; NumPy multislice backend still available

--- a/toupy/tomo/multislice.py
+++ b/toupy/tomo/multislice.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Multislice wave-propagation engine for tomographic reconstruction.
+
+This module provides the building blocks for the two-pass tomographic
+reconstruction method implemented in :mod:`toupy.tomo.twopass`.  It
+contains a Fresnel propagator that can be corrected for the mean
+refractive index of the traversed material (vacuum propagator is the
+standard multislice approximation; matter-corrected propagator is the
+physically consistent version), and a MultisliceEngine that computes:
+
+  * the **forward pass**: probe → exit wave through a stack of thin slices
+  * the **backward pass** (adjoint): residual → gradient of the loss
+    w.r.t. the projected refractive-index decrements and absorptions of
+    every slice — used by the gradient-descent optimiser in Pass 2.
+
+Physical convention
+-------------------
+Refractive index:       n(r) = 1 − δ(r) + iβ(r)     (δ, β ≥ 0)
+Transmission per slice: T_j  = exp(−k₀ (β_j + iδ_j) Δz)
+Fresnel propagator:
+
+  Vacuum:
+    H_vac(f_x, f_y; Δz) = exp(−iπλΔz (f_x² + f_y²))
+
+  Matter-corrected (paraxial, n_mean = 1 − δ̄):
+    H_mat(f_x, f_y; Δz) = exp(−iπ(λ/n_mean)Δz (f_x² + f_y²))
+                         = H_vac · exp(−iπλΔzδ̄ (f_x² + f_y²))
+
+where f_x, f_y are spatial frequencies in cycles m⁻¹.
+
+The correction is tiny for hard X-rays (δ̄ ~ 10⁻⁶) but becomes
+significant for soft X-rays and electrons.
+
+Gradient derivation (Wirtinger calculus)
+-----------------------------------------
+Loss:   L = ½ ‖U_N − U_meas‖²
+
+Forward pass:
+    W_j  = T_j  ⊙  U_{j−1}      (transmission)
+    U_j  = P_Δz[W_j]             (propagation)
+
+Backward pass (using adjoint operators):
+    r_N  = U_N − U_meas
+    For j = N, …, 1:
+        s_j       = P_{−Δz}[r_j]                       (adjoint propagation)
+        ∂L/∂δ_j   = +2 k₀ Δz  Im[ W_j · conj(s_j) ]
+        ∂L/∂β_j   = −2 k₀ Δz  Re[ W_j · conj(s_j) ]
+        r_{j−1}   = conj(T_j) ⊙ s_j                   (adjoint transmission)
+
+References
+----------
+Goodman (2005) "Introduction to Fourier Optics", 3rd ed.
+Paganin (2006) "Coherent X-Ray Optics", Oxford.
+Kirkland (2010) "Advanced Computing in Electron Microscopy", Springer.
+"""
+
+# standard library
+import warnings
+
+# third-party
+import numpy as np
+from scipy.fft import fft2, ifft2, fftfreq
+from scipy.ndimage import rotate as ndimage_rotate
+
+__all__ = [
+    "FresnelPropagator",
+    "MultisliceEngine",
+    "extract_slices_from_volume",
+    "scatter_gradient_to_volume",
+    "mean_refractive_index_profile",
+]
+
+
+# ---------------------------------------------------------------------------
+# Fresnel propagator
+# ---------------------------------------------------------------------------
+
+class FresnelPropagator:
+    """
+    Paraxial Fresnel propagator in the Fourier domain.
+
+    Pre-computes the squared-frequency grid at construction time so that
+    repeated propagation calls (same grid, different distance or n_mean)
+    avoid rebuilding it.
+
+    Parameters
+    ----------
+    shape : tuple (Ny, Nx)
+        Transverse grid size.
+    pixel_size : float
+        Real-space pixel size [m].
+    wavelength : float
+        X-ray wavelength [m].
+    """
+
+    def __init__(self, shape, pixel_size, wavelength):
+        self.shape = shape
+        self.pixel_size = float(pixel_size)
+        self.wavelength = float(wavelength)
+
+        Ny, Nx = shape
+        fx = fftfreq(Nx, d=self.pixel_size)   # cycles m⁻¹
+        fy = fftfreq(Ny, d=self.pixel_size)
+        FX, FY = np.meshgrid(fx, fy, indexing="xy")
+        # f² grid stored for reuse; shape (Ny, Nx)
+        self._f2 = (FX ** 2 + FY ** 2).astype(np.float64)
+
+    # ------------------------------------------------------------------
+    def _kernel(self, distance, delta_mean=0.0):
+        """
+        Build the Fresnel kernel H(f; Δz, δ̄).
+
+        Parameters
+        ----------
+        distance : float
+            Propagation distance [m].  Positive → forward, negative → backward.
+        delta_mean : float, optional
+            Mean refractive-index decrement of the traversed layer.
+            δ̄ = 0 gives the standard vacuum propagator.
+            Provide the layer-averaged value from the step-1 volume to
+            obtain the matter-corrected propagator.
+
+        Returns
+        -------
+        H : ndarray, complex128, shape (Ny, Nx)
+        """
+        n_mean = 1.0 - float(delta_mean)
+        # effective wavelength in medium: λ_eff ≈ λ/n_mean ≈ λ(1 + δ̄)
+        lam_eff = self.wavelength / n_mean
+        phase = -np.pi * lam_eff * distance * self._f2
+        return np.exp(1j * phase)
+
+    # ------------------------------------------------------------------
+    def propagate(self, wavefield, distance, delta_mean=0.0):
+        """
+        Propagate a complex wavefield by ``distance`` metres.
+
+        Parameters
+        ----------
+        wavefield : ndarray, complex, shape (Ny, Nx)
+        distance : float
+            [m]; positive = along the optical axis (forward).
+        delta_mean : float, optional
+            Mean δ of the traversed layer for matter-corrected propagation.
+
+        Returns
+        -------
+        ndarray, complex, shape (Ny, Nx)
+        """
+        H = self._kernel(distance, delta_mean=delta_mean)
+        return ifft2(fft2(wavefield) * H)
+
+    def propagate_adjoint(self, wavefield, distance, delta_mean=0.0):
+        """
+        Adjoint propagation: backward Fresnel propagation by ``distance``.
+
+        For a lossless medium the adjoint equals forward propagation by
+        ``−distance`` (phase conjugation / time reversal).
+
+        Parameters
+        ----------
+        wavefield : ndarray, complex, shape (Ny, Nx)
+        distance : float   [m]
+        delta_mean : float, optional
+
+        Returns
+        -------
+        ndarray, complex, shape (Ny, Nx)
+        """
+        return self.propagate(wavefield, -distance, delta_mean=delta_mean)
+
+
+# ---------------------------------------------------------------------------
+# Multislice engine
+# ---------------------------------------------------------------------------
+
+class MultisliceEngine:
+    """
+    Forward and adjoint multislice wave-propagation engine.
+
+    The object is discretised into ``n_slices`` thin slabs, each of
+    thickness ``slice_thickness`` metres.  For every slice the engine:
+
+      1. Multiplies the current wavefield by the transmission function
+         T_j = exp(−k₀(β_j + iδ_j)Δz).
+      2. Propagates the resulting field to the next slice using a
+         Fresnel propagator (vacuum or matter-corrected).
+
+    The adjoint of this forward operator provides exact gradients of the
+    squared-residual loss with respect to the slice δ and β maps.
+
+    Parameters
+    ----------
+    shape : tuple (Ny, Nx)
+        Transverse grid size (must match the exit-wave shape).
+    pixel_size : float
+        Real-space pixel size [m].
+    wavelength : float
+        X-ray wavelength [m].
+    slice_thickness : float
+        Thickness of each slice [m].  For isotropic voxels set this equal
+        to ``pixel_size``.
+    """
+
+    def __init__(self, shape, pixel_size, wavelength, slice_thickness):
+        self.shape = shape
+        self.pixel_size = float(pixel_size)
+        self.wavelength = float(wavelength)
+        self.slice_thickness = float(slice_thickness)
+        self.k0 = 2.0 * np.pi / self.wavelength
+        self._prop = FresnelPropagator(shape, pixel_size, wavelength)
+
+    # ------------------------------------------------------------------
+    def transmission(self, delta_slice, beta_slice):
+        """
+        Compute the complex transmission for a single slice.
+
+        T(x,y) = exp(−k₀ (β(x,y) + iδ(x,y)) Δz)
+
+        Parameters
+        ----------
+        delta_slice : ndarray, real, shape (Ny, Nx)
+        beta_slice  : ndarray, real, shape (Ny, Nx)
+
+        Returns
+        -------
+        T : ndarray, complex128, shape (Ny, Nx)
+        """
+        dz = self.slice_thickness
+        return np.exp(-self.k0 * dz * (beta_slice + 1j * delta_slice))
+
+    # ------------------------------------------------------------------
+    def forward(self, delta_slices, beta_slices, probe,
+                delta_means=None, store_wavefields=False):
+        """
+        Forward multislice propagation.
+
+        Parameters
+        ----------
+        delta_slices : ndarray, real, shape (n_slices, Ny, Nx)
+            Refractive-index decrement maps, one per slice.
+        beta_slices  : ndarray, real, shape (n_slices, Ny, Nx)
+            Absorption maps, one per slice.
+        probe : ndarray, complex, shape (Ny, Nx)
+            Incident wavefield entering the first slice.
+        delta_means : array_like of float, length n_slices, optional
+            Mean δ in each slice for the matter-corrected propagator.
+            If None, the vacuum propagator is used (δ̄ = 0 for all slices).
+        store_wavefields : bool, optional
+            If True, return the intermediate wavefields needed for the
+            adjoint pass.  Required for gradient computation.
+
+        Returns
+        -------
+        U_exit : ndarray, complex, shape (Ny, Nx)
+            Exit wavefield after the last slice.
+        wavefields : dict  (only when ``store_wavefields=True``)
+            ``wavefields["W"][j]``: wavefield *after* transmission, *before*
+            propagation, at slice j (0-indexed).
+            ``wavefields["U"][j]``: wavefield *after* propagation at slice j.
+            ``wavefields["U"][-1]`` == ``wavefields["U"][0]`` == probe (entry).
+            ``wavefields["T"][j]``: transmission function at slice j.
+        """
+        n_slices = delta_slices.shape[0]
+        if delta_means is None:
+            delta_means = np.zeros(n_slices)
+
+        dz = self.slice_thickness
+        U = probe.astype(complex, copy=True)
+
+        if store_wavefields:
+            W_list = []   # after transmission, before propagation
+            T_list = []   # transmission functions
+            U_list = [U.copy()]  # U_list[0] = probe entering slice 0
+
+        for j in range(n_slices):
+            T_j = self.transmission(delta_slices[j], beta_slices[j])
+            W_j = T_j * U              # apply transmission
+            U   = self._prop.propagate(W_j, dz, delta_mean=delta_means[j])
+            if store_wavefields:
+                T_list.append(T_j)
+                W_list.append(W_j)
+                U_list.append(U.copy())   # U_list[j+1] = after propagation j
+
+        if store_wavefields:
+            return U, {"W": W_list, "T": T_list, "U": U_list}
+        return U
+
+    # ------------------------------------------------------------------
+    def gradient(self, wavefields, u_measured, delta_means=None):
+        """
+        Compute gradients via the adjoint (backward) pass.
+
+        Must be called with ``wavefields`` returned by :meth:`forward`
+        (using ``store_wavefields=True``).
+
+        Parameters
+        ----------
+        wavefields : dict
+            As returned by :meth:`forward` with ``store_wavefields=True``.
+        u_measured : ndarray, complex, shape (Ny, Nx)
+            Reference (measured) exit wave.
+        delta_means : array_like of float, optional
+            Same values used during the forward pass.
+
+        Returns
+        -------
+        grad_delta : ndarray, real, shape (n_slices, Ny, Nx)
+            ∂L/∂δ_j for each slice.
+        grad_beta  : ndarray, real, shape (n_slices, Ny, Nx)
+            ∂L/∂β_j for each slice.
+        loss : float
+            Squared-residual loss ½‖U_exit − U_meas‖².
+        """
+        W_list = wavefields["W"]
+        T_list = wavefields["T"]
+        U_list = wavefields["U"]    # length n_slices + 1
+
+        n_slices = len(W_list)
+        if delta_means is None:
+            delta_means = np.zeros(n_slices)
+
+        dz = self.slice_thickness
+        k0 = self.k0
+        scale = k0 * dz   # common factor in gradient formulas
+
+        # Residual at exit plane
+        U_exit = U_list[n_slices]    # = U_list[-1]
+        residual = U_exit - u_measured
+        loss = 0.5 * float(np.sum(np.abs(residual) ** 2))
+
+        grad_delta = np.zeros((n_slices,) + self.shape, dtype=np.float64)
+        grad_beta  = np.zeros((n_slices,) + self.shape, dtype=np.float64)
+
+        # Initialise adjoint state r_N = residual
+        r = residual.astype(complex, copy=True)
+
+        for j in range(n_slices - 1, -1, -1):
+            # Adjoint of propagation: backward propagation by -Δz
+            s_j = self._prop.propagate_adjoint(r, dz, delta_mean=delta_means[j])
+
+            # Gradient contributions from slice j
+            # ∂L/∂δ_j = +2k₀Δz · Im[W_j · conj(s_j)]
+            # ∂L/∂β_j = −2k₀Δz · Re[W_j · conj(s_j)]
+            cross = W_list[j] * np.conj(s_j)
+            grad_delta[j] =  scale * np.imag(cross)
+            grad_beta[j]  = -scale * np.real(cross)
+
+            # Adjoint of transmission: r_{j-1} = conj(T_j) ⊙ s_j
+            r = np.conj(T_list[j]) * s_j
+
+        return grad_delta, grad_beta, loss
+
+    # ------------------------------------------------------------------
+    def loss_and_gradient(self, delta_slices, beta_slices, probe,
+                          u_measured, delta_means=None):
+        """
+        Convenience: forward + backward in one call.
+
+        Returns
+        -------
+        loss : float
+        grad_delta : ndarray  (n_slices, Ny, Nx)
+        grad_beta  : ndarray  (n_slices, Ny, Nx)
+        u_exit : ndarray, complex  (Ny, Nx)
+            Simulated exit wave (useful for monitoring convergence).
+        """
+        u_exit, wf = self.forward(delta_slices, beta_slices, probe,
+                                  delta_means=delta_means,
+                                  store_wavefields=True)
+        gd, gb, loss = self.gradient(wf, u_measured, delta_means=delta_means)
+        return loss, gd, gb, u_exit
+
+
+# ---------------------------------------------------------------------------
+# Volume ↔ slice utilities
+# ---------------------------------------------------------------------------
+
+def extract_slices_from_volume(delta_vol, beta_vol, theta_deg, n_slices=None):
+    """
+    Extract 2D transverse slices from a 3D volume at a given rotation angle.
+
+    The volume is rotated about the y-axis (axis 1) by ``theta_deg``
+    degrees so that the beam direction aligns with axis 0.  The resulting
+    rotated array is then sliced along axis 0 to obtain ``n_slices``
+    2D (Ny × Nx) maps of δ and β perpendicular to the beam.
+
+    If ``n_slices`` < Nz, adjacent z-layers are averaged to form thicker
+    effective slices; the corresponding slice thickness then becomes
+    Nz/n_slices × pixel_size.
+
+    Parameters
+    ----------
+    delta_vol : ndarray, real, shape (Nz, Ny, Nx)
+    beta_vol  : ndarray, real, shape (Nz, Ny, Nx)
+    theta_deg : float
+        Rotation angle in degrees.
+    n_slices  : int, optional
+        Number of output slices.  Defaults to Nz (one per z-pixel).
+
+    Returns
+    -------
+    delta_slices : ndarray, shape (n_slices, Ny, Nx)
+    beta_slices  : ndarray, shape (n_slices, Ny, Nx)
+    delta_means  : ndarray, shape (n_slices,)
+        Transverse-plane mean of δ per slice (for matter-corrected propagator).
+    """
+    Nz, Ny, Nx = delta_vol.shape
+
+    # Rotate in the xz-plane (axes 2 and 0) about the y-axis.
+    # order=1 (trilinear) is fast and sufficient; use order=3 for higher accuracy.
+    kwargs = dict(axes=(2, 0), reshape=False, order=1, mode="constant", cval=0.0)
+    delta_rot = ndimage_rotate(delta_vol.astype(np.float64), theta_deg, **kwargs)
+    beta_rot  = ndimage_rotate(beta_vol.astype(np.float64),  theta_deg, **kwargs)
+
+    if n_slices is None or n_slices == Nz:
+        delta_slices = delta_rot
+        beta_slices  = beta_rot
+    else:
+        # Group consecutive z-layers by averaging
+        k = Nz // n_slices
+        if k == 0:
+            raise ValueError(
+                f"n_slices={n_slices} > Nz={Nz}.  "
+                "Cannot have more slices than z-pixels."
+            )
+        n_use = k * n_slices
+        delta_slices = delta_rot[:n_use].reshape(n_slices, k, Ny, Nx).mean(axis=1)
+        beta_slices  = beta_rot[:n_use].reshape(n_slices, k, Ny, Nx).mean(axis=1)
+
+    delta_means = delta_slices.mean(axis=(1, 2))   # shape (n_slices,)
+    return delta_slices, beta_slices, delta_means
+
+
+def scatter_gradient_to_volume(grad_delta_slices, grad_beta_slices,
+                               theta_deg, volume_shape, n_slices=None):
+    """
+    Accumulate 2D slice gradients back into the 3D volume gradient.
+
+    This is the adjoint of :func:`extract_slices_from_volume`: it
+    back-rotates the per-slice gradient maps by ``−theta_deg`` and scatters
+    them into the corresponding z-layers of the 3D volume.
+
+    Parameters
+    ----------
+    grad_delta_slices : ndarray, real, shape (n_slices, Ny, Nx)
+    grad_beta_slices  : ndarray, real, shape (n_slices, Ny, Nx)
+    theta_deg : float
+    volume_shape : tuple (Nz, Ny, Nx)
+    n_slices : int, optional
+        Must match the value used in :func:`extract_slices_from_volume`.
+
+    Returns
+    -------
+    grad_delta_vol : ndarray, real, shape (Nz, Ny, Nx)
+    grad_beta_vol  : ndarray, real, shape (Nz, Ny, Nx)
+    """
+    Nz, Ny, Nx = volume_shape
+
+    if n_slices is not None and n_slices < Nz:
+        k = Nz // n_slices
+        n_use = k * n_slices
+        # Expand: each slice gradient distributes equally over k z-layers
+        gd_full = np.repeat(grad_delta_slices, k, axis=0) / k
+        gb_full = np.repeat(grad_beta_slices,  k, axis=0) / k
+        # Pad remaining layers (if Nz not divisible by n_slices) with zeros
+        if n_use < Nz:
+            pad = np.zeros((Nz - n_use, Ny, Nx))
+            gd_full = np.concatenate([gd_full, pad], axis=0)
+            gb_full = np.concatenate([gb_full, pad], axis=0)
+    else:
+        gd_full = grad_delta_slices
+        gb_full = grad_beta_slices
+
+    # Back-rotate by −theta (adjoint of the forward rotation)
+    kwargs = dict(axes=(2, 0), reshape=False, order=1, mode="constant", cval=0.0)
+    grad_delta_vol = ndimage_rotate(gd_full, -theta_deg, **kwargs)
+    grad_beta_vol  = ndimage_rotate(gb_full, -theta_deg, **kwargs)
+
+    return grad_delta_vol, grad_beta_vol
+
+
+def mean_refractive_index_profile(delta_vol, beta_vol, theta_deg, n_slices=None):
+    """
+    Compute mean δ̄ and β̄ per slice at angle ``theta_deg``.
+
+    A lightweight wrapper around :func:`extract_slices_from_volume` that
+    only returns the per-slice means (no need to rotate beta for the
+    propagator, since only δ̄ enters).
+
+    Parameters
+    ----------
+    delta_vol : ndarray, shape (Nz, Ny, Nx)
+    beta_vol  : ndarray, shape (Nz, Ny, Nx)  (accepted but not used here)
+    theta_deg : float
+    n_slices  : int, optional
+
+    Returns
+    -------
+    delta_means : ndarray, shape (n_slices,)
+    """
+    _, _, delta_means = extract_slices_from_volume(
+        delta_vol, beta_vol, theta_deg, n_slices=n_slices
+    )
+    return delta_means

--- a/toupy/tomo/multislice_torch.py
+++ b/toupy/tomo/multislice_torch.py
@@ -1,0 +1,772 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+PyTorch backend for the multislice wave-propagation engine.
+
+This module mirrors ``multislice.py`` but uses PyTorch as the compute
+backend, giving transparent access to:
+
+    * CUDA  — NVIDIA GPUs via cuFFT / cuBLAS
+    * MPS   — Apple Silicon GPU via Metal Performance Shaders
+    * CPU   — multi-threaded torch (comparable to NumPy at small sizes;
+              faster at large sizes due to better thread-pool utilisation)
+
+Automatic device selection
+--------------------------
+    device = select_device()          # CUDA > MPS > CPU  (automatic)
+    device = select_device("cpu")     # force CPU
+    device = select_device("mps")     # force Apple GPU
+    device = select_device("cuda")    # force NVIDIA GPU
+
+Gradient checkpointing
+-----------------------
+For volumes >= 512³ the intermediate wavefields stored during the forward
+pass start to dominate GPU memory.  ``TorchMultisliceEngine`` supports
+gradient checkpointing: only the entry wavefield of each of the
+``n_checkpoints`` segments is retained; within-segment forward passes are
+recomputed during backpropagation.  Memory scales as
+O(n_checkpoints × N²) instead of O(N_slices × N²).
+
+MPS rotation workaround
+------------------------
+PyTorch's ``grid_sampler_3d`` is not yet implemented on MPS (as of 2.x).
+``rotate_volume_torch`` uses batched 2D ``grid_sample`` over the y-axis
+instead, which is mathematically equivalent for a rotation in the xz-plane
+and runs natively on MPS, CUDA, and CPU.
+
+Precision
+---------
+This module uses **float32 / complex64** throughout (even on CPU) for
+consistency with GPU paths.  float32 gives ~7 significant digits, more than
+sufficient for refractive-index values in the range 10⁻⁶ – 10⁻³.  The
+NumPy module (``multislice.py``) retains float64 for users who prefer it.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+__all__ = [
+    "select_device",
+    "device_info",
+    "warmup_device",
+    "rotate_volume_torch",
+    "TorchFresnelPropagator",
+    "TorchMultisliceEngine",
+    "extract_slices_torch",
+    "scatter_gradient_torch",
+    "tv_grad_torch",
+    "TorchAdamState",
+]
+
+
+# ---------------------------------------------------------------------------
+# Device management
+# ---------------------------------------------------------------------------
+
+def select_device(prefer: Optional[str] = None) -> torch.device:
+    """
+    Return the best available torch device.
+
+    Priority (when ``prefer`` is ``None``): CUDA > MPS > CPU.
+
+    Parameters
+    ----------
+    prefer : str, optional
+        ``'cuda'``, ``'mps'``, or ``'cpu'``.  Raises ``RuntimeError`` if
+        the requested device is unavailable.
+
+    Returns
+    -------
+    torch.device
+    """
+    if prefer is not None:
+        prefer = prefer.lower()
+        if prefer == "cuda" and not torch.cuda.is_available():
+            raise RuntimeError("CUDA requested but not available.")
+        if prefer == "mps" and not torch.backends.mps.is_available():
+            raise RuntimeError("MPS requested but not available.")
+        return torch.device(prefer)
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    if torch.backends.mps.is_available():
+        return torch.device("mps")
+    return torch.device("cpu")
+
+
+def device_info(device: torch.device) -> str:
+    """Return a human-readable one-line description of the device."""
+    name = str(device)
+    if name.startswith("cuda"):
+        gpu   = torch.cuda.get_device_name(device)
+        mem   = torch.cuda.get_device_properties(device).total_memory / 1e9
+        return f"CUDA  — {gpu}  ({mem:.0f} GB VRAM)"
+    if name == "mps":
+        return "MPS   — Apple Silicon GPU (Metal Performance Shaders)"
+    return f"CPU   — torch {torch.__version__}  ({torch.get_num_threads()} threads)"
+
+
+def warmup_device(device: torch.device, size: int = 64) -> None:
+    """
+    Run a tiny FFT and element-wise op to trigger JIT compilation.
+
+    The first operation on a GPU device (especially MPS) can take several
+    hundred milliseconds for shader/kernel compilation.  Call this once
+    before timing-sensitive code.
+    """
+    x = torch.randn(size, size, dtype=torch.complex64, device=device)
+    _ = torch.fft.ifft2(torch.fft.fft2(x) * x)
+    if str(device).startswith("cuda"):
+        torch.cuda.synchronize(device)
+
+
+# ---------------------------------------------------------------------------
+# Volume rotation  (MPS-compatible via batched 2-D grid_sample)
+# ---------------------------------------------------------------------------
+
+def rotate_volume_torch(vol: torch.Tensor, theta_deg: float) -> torch.Tensor:
+    """
+    Rotate a 3-D volume in the (x, z) plane.
+
+    Equivalent to ``scipy.ndimage.rotate(vol, theta_deg, axes=(2, 0),
+    reshape=False, order=1, mode='constant', cval=0)`` in the volume
+    interior.  Near the boundary the two implementations differ slightly:
+    scipy returns a hard 0 for any source coordinate outside the domain,
+    while PyTorch bilinear still weights the nearest valid pixel; in practice
+    this only affects voxels within ~1 pixel of the rotated cube's edge and
+    is inconsequential for tomographic volumes where boundary voxels are air.
+
+    Implementation note
+    -------------------
+    ``torch.nn.functional.grid_sampler_3d`` is not available on MPS.
+    We work around this by treating each (Nz, Nx) face (constant y-slice)
+    as an independent 2-D image and applying batched ``grid_sample`` over
+    the Ny slices.  The result matches scipy in the interior to < 1e-4 and
+    runs on MPS, CUDA, and CPU.
+
+    The inverse-mapping matrix (output → input, as required by
+    ``affine_grid``) follows the scipy ``axes=(2, 0)`` convention::
+
+        ⎡ x_in ⎤   ⎡ cos θ  −sin θ ⎤   ⎡ x_out ⎤
+        ⎣ z_in ⎦ = ⎣ sin θ   cos θ ⎦ × ⎣ z_out ⎦
+
+    Parameters
+    ----------
+    vol : torch.Tensor, real float32, shape (Nz, Ny, Nx)
+    theta_deg : float
+        Rotation angle in degrees (same sign convention as scipy).
+
+    Returns
+    -------
+    torch.Tensor, same shape, dtype, and device as ``vol``.
+    """
+    Nz, Ny, Nx = vol.shape
+    device = vol.device
+    dtype_in = vol.dtype
+
+    theta = math.radians(theta_deg)
+    c = math.cos(theta)
+    s = math.sin(theta)
+
+    # 2×3 affine matrix  [x_in, z_in] = R @ [x_out, z_out, 1]
+    # PyTorch affine_grid encodes the OUTPUT→INPUT mapping.
+    #
+    # scipy.ndimage.rotate(axes=(2,0), angle=θ) uses the rotation matrix
+    #   [[cos, sin], [-sin, cos]]
+    # acting on (axis2, axis0) = (x, z) in the OUTPUT→INPUT sense:
+    #   x_in_c =  c·x_out_c + s·z_out_c          (centered pixel coords)
+    #   z_in_c = -s·x_out_c + c·z_out_c
+    # Forward (INPUT→OUTPUT):
+    #   x_out_c =  c·x_in_c - s·z_in_c
+    #   z_out_c =  s·x_in_c + c·z_in_c
+    #
+    # affine_grid works in NORMALISED coords [-1, 1].  The mapping between
+    # normalised and pixel centred coords is:
+    #   x_norm = 2·x_c / (Nx-1),   z_norm = 2·z_c / (Nz-1)
+    #
+    # Substituting the OUTPUT→INPUT mapping into normalised coords gives:
+    #   x_in_norm =  c·x_out_norm + s·(Nz-1)/(Nx-1)·z_out_norm
+    #   z_in_norm = -s·(Nx-1)/(Nz-1)·x_out_norm + c·z_out_norm
+    #
+    # When Nz == Nx the aspect-ratio factors cancel and we get [[c,+s],[-s,c]].
+    #
+    # NOTE: an earlier version of this matrix had the signs of the off-diagonal
+    # elements flipped ([[c,-s*az],[+s*ax,c]]), which caused the GPU rotation to
+    # go in the OPPOSITE direction from scipy.  This produced a mirror-image
+    # reconstruction on GPU vs CPU and has now been corrected.
+    az = (Nz - 1) / (Nx - 1) if Nx != 1 else 1.0   # aspect ratio z/x
+    ax = (Nx - 1) / (Nz - 1) if Nz != 1 else 1.0   # aspect ratio x/z
+    R = torch.tensor([[c,     s * az, 0.0],
+                      [-s * ax,  c,  0.0]], dtype=torch.float32, device=device)
+
+    # Compute the sampling grid for a SINGLE y-slice (the Nz×Nx plane).
+    # All y-slices share the same xz-rotation, so we only need shape (1,1,Nz,Nx).
+    # This allocates ~2 MB instead of the ~766 MB that would result from passing
+    # a full (Ny, 2, 3) R_batch to affine_grid.
+    R_1     = R.unsqueeze(0)                                          # 1,2,3
+    grid_1  = F.affine_grid(R_1, (1, 1, Nz, Nx), align_corners=True) # 1,Nz,Nx,2
+
+    # Reshape volume to batch of 2-D images: (Ny, 1, Nz, Nx)
+    vol_batch = vol.to(torch.float32).permute(1, 0, 2).unsqueeze(1)  # Ny,1,Nz,Nx
+
+    # Expand grid to (Ny, Nz, Nx, 2) — zero-copy view; grid_sample accepts
+    # non-contiguous grids on CUDA, CPU, and MPS (PyTorch ≥ 2.0).
+    grid    = grid_1.expand(Ny, -1, -1, -1)                          # Ny,Nz,Nx,2
+
+    rotated = F.grid_sample(vol_batch, grid,
+                            mode="bilinear",
+                            padding_mode="zeros",
+                            align_corners=True)                       # Ny,1,Nz,Nx
+
+    out = rotated.squeeze(1).permute(1, 0, 2)                        # Nz,Ny,Nx
+    return out.to(dtype_in)
+
+
+# ---------------------------------------------------------------------------
+# Fresnel propagator
+# ---------------------------------------------------------------------------
+
+class TorchFresnelPropagator:
+    """
+    Paraxial Fresnel propagator in the Fourier domain (PyTorch backend).
+
+    Mirrors :class:`~toupy.tomo.multislice.FresnelPropagator` with
+    complex64 arithmetic on the selected device.
+
+    Parameters
+    ----------
+    shape : tuple (Ny, Nx)
+    pixel_size : float   [m]
+    wavelength : float   [m]
+    device : torch.device
+    """
+
+    def __init__(self, shape: Tuple[int, int], pixel_size: float,
+                 wavelength: float, device: torch.device) -> None:
+        self.shape      = shape
+        self.pixel_size = float(pixel_size)
+        self.wavelength = float(wavelength)
+        self.device     = device
+
+        Ny, Nx = shape
+        fx = torch.fft.fftfreq(Nx, d=self.pixel_size, device=device)
+        fy = torch.fft.fftfreq(Ny, d=self.pixel_size, device=device)
+        # indexing='xy': first index = x (cols), second = y (rows)
+        FX, FY = torch.meshgrid(fx, fy, indexing="xy")
+        self._f2 = (FX ** 2 + FY ** 2).to(torch.float32)   # (Ny, Nx)
+
+    # ------------------------------------------------------------------
+    def _kernel(self, distance: float, delta_mean: float = 0.0) -> torch.Tensor:
+        n_mean  = 1.0 - float(delta_mean)
+        lam_eff = self.wavelength / n_mean
+        phase   = -math.pi * lam_eff * float(distance) * self._f2
+        return torch.exp(1j * phase)                        # complex64
+
+    def propagate(self, wavefield: torch.Tensor,
+                  distance: float, delta_mean: float = 0.0) -> torch.Tensor:
+        H = self._kernel(distance, delta_mean)
+        return torch.fft.ifft2(torch.fft.fft2(wavefield) * H)
+
+    def propagate_adjoint(self, wavefield: torch.Tensor,
+                          distance: float, delta_mean: float = 0.0) -> torch.Tensor:
+        return self.propagate(wavefield, -distance, delta_mean)
+
+
+# ---------------------------------------------------------------------------
+# Multislice engine
+# ---------------------------------------------------------------------------
+
+class TorchMultisliceEngine:
+    """
+    Forward and adjoint multislice engine (PyTorch backend).
+
+    Mirrors :class:`~toupy.tomo.multislice.MultisliceEngine` with float32
+    arithmetic.  All tensors live on ``device``.
+
+    Parameters
+    ----------
+    shape : tuple (Ny, Nx)
+    pixel_size : float   [m]
+    wavelength : float   [m]
+    slice_thickness : float   [m]
+    device : torch.device, optional
+        Auto-selected if ``None``.
+    n_checkpoints : int, optional
+        Number of gradient-checkpointing segments (default 1 = no
+        checkpointing).  Increase to reduce GPU memory at the cost of one
+        extra partial forward pass per segment.
+    """
+
+    def __init__(self, shape: Tuple[int, int], pixel_size: float,
+                 wavelength: float, slice_thickness: float,
+                 device: Optional[torch.device] = None,
+                 n_checkpoints: int = 1) -> None:
+        self.shape          = shape
+        self.device         = device or select_device()
+        self.pixel_size     = float(pixel_size)
+        self.wavelength     = float(wavelength)
+        self.slice_thickness = float(slice_thickness)
+        self.k0             = 2.0 * math.pi / self.wavelength
+        self.n_checkpoints  = max(1, int(n_checkpoints))
+        self._prop          = TorchFresnelPropagator(
+                                  shape, pixel_size, wavelength, self.device)
+
+    # ------------------------------------------------------------------
+    def _to(self, arr) -> torch.Tensor:
+        """Convert numpy array or torch tensor to complex64 on device."""
+        if isinstance(arr, np.ndarray):
+            arr = torch.from_numpy(arr)
+        return arr.to(device=self.device, dtype=torch.complex64)
+
+    def _to_real(self, arr) -> torch.Tensor:
+        """Convert numpy array or torch tensor to float32 on device."""
+        if isinstance(arr, np.ndarray):
+            arr = torch.from_numpy(arr)
+        return arr.to(device=self.device, dtype=torch.float32)
+
+    # ------------------------------------------------------------------
+    def transmission(self, delta_slice: torch.Tensor,
+                     beta_slice: torch.Tensor) -> torch.Tensor:
+        """
+        T(x,y) = exp(−k₀ (β + iδ) Δz)
+        """
+        dz = self.slice_thickness
+        d  = self._to_real(delta_slice)
+        b  = self._to_real(beta_slice)
+        return torch.exp(-self.k0 * dz * (b + 1j * d))     # complex64
+
+    # ------------------------------------------------------------------
+    def forward(self, delta_slices, beta_slices, probe,
+                delta_means=None, store_wavefields: bool = False):
+        """
+        Forward multislice propagation.
+
+        Parameters
+        ----------
+        delta_slices : array-like, shape (n_slices, Ny, Nx)
+        beta_slices  : array-like, shape (n_slices, Ny, Nx)
+        probe        : array-like, complex, shape (Ny, Nx)
+        delta_means  : array-like of float, length n_slices, optional
+        store_wavefields : bool
+
+        Returns
+        -------
+        U_exit : torch.Tensor, complex64, shape (Ny, Nx)
+        wavefields : dict   (only when ``store_wavefields=True``)
+        """
+        if isinstance(delta_slices, np.ndarray):
+            delta_slices = torch.from_numpy(delta_slices)
+        if isinstance(beta_slices, np.ndarray):
+            beta_slices = torch.from_numpy(beta_slices)
+
+        n_slices = delta_slices.shape[0]
+        if delta_means is None:
+            delta_means = torch.zeros(n_slices, dtype=torch.float32)
+        elif isinstance(delta_means, np.ndarray):
+            delta_means = torch.from_numpy(delta_means)
+
+        # Move delta_means to CPU *once* as a plain Python list.
+        # Calling float(delta_means[j]) inside the loop forces a device→host
+        # sync on every slab (one Metal command-buffer flush per call on MPS,
+        # or a cudaDeviceSynchronize equivalent on CUDA).  With n_slices=16 and
+        # 450 angles that is 14 400 stalls per iteration — the dominant runtime
+        # cost on both MPS and CUDA.  One .cpu().tolist() costs a single sync.
+        if isinstance(delta_means, torch.Tensor) and delta_means.device.type != 'cpu':
+            _dm = delta_means.detach().cpu().tolist()
+        elif isinstance(delta_means, torch.Tensor):
+            _dm = delta_means.tolist()
+        else:
+            _dm = [float(x) for x in delta_means]
+
+        dz = self.slice_thickness
+        U  = self._to(probe).clone()
+
+        if store_wavefields:
+            W_list, T_list, U_list = [], [], [U.clone()]
+
+        for j in range(n_slices):
+            T_j = self.transmission(delta_slices[j], beta_slices[j])
+            W_j = T_j * U
+            U   = self._prop.propagate(W_j, dz, delta_mean=_dm[j])
+            if store_wavefields:
+                T_list.append(T_j)
+                W_list.append(W_j)
+                U_list.append(U.clone())
+
+        if store_wavefields:
+            return U, {"W": W_list, "T": T_list, "U": U_list}
+        return U
+
+    # ------------------------------------------------------------------
+    def gradient(self, wavefields: Dict, u_measured,
+                 delta_means=None) -> Tuple[torch.Tensor, torch.Tensor, float]:
+        """
+        Adjoint (backward) pass — same formula as the NumPy version.
+
+        Returns
+        -------
+        grad_delta : float32, shape (n_slices, Ny, Nx)
+        grad_beta  : float32, shape (n_slices, Ny, Nx)
+        loss       : float
+        """
+        W_list   = wavefields["W"]
+        T_list   = wavefields["T"]
+        U_list   = wavefields["U"]
+        n_slices = len(W_list)
+
+        if delta_means is None:
+            delta_means = torch.zeros(n_slices, dtype=torch.float32)
+        elif isinstance(delta_means, np.ndarray):
+            delta_means = torch.from_numpy(delta_means)
+
+        dz    = self.slice_thickness
+        scale = self.k0 * dz
+
+        U_exit   = U_list[n_slices]
+        u_meas_t = self._to(u_measured)
+        residual = U_exit - u_meas_t
+        loss     = 0.5 * float(residual.abs().pow(2).sum().cpu())
+
+        # One sync to get all delta_means on CPU (avoids per-slab sync in loop)
+        if isinstance(delta_means, torch.Tensor) and delta_means.device.type != 'cpu':
+            _dm = delta_means.detach().cpu().tolist()
+        elif isinstance(delta_means, torch.Tensor):
+            _dm = delta_means.tolist()
+        else:
+            _dm = [float(x) for x in delta_means]
+
+        grad_delta = torch.zeros((n_slices,) + self.shape,
+                                 dtype=torch.float32, device=self.device)
+        grad_beta  = torch.zeros((n_slices,) + self.shape,
+                                 dtype=torch.float32, device=self.device)
+        r = residual.clone()
+
+        for j in range(n_slices - 1, -1, -1):
+            s_j = self._prop.propagate_adjoint(r, dz, delta_mean=_dm[j])
+            cross           = W_list[j] * s_j.conj()
+            grad_delta[j]   =  scale * cross.imag
+            grad_beta[j]    = -scale * cross.real
+            r = T_list[j].conj() * s_j
+
+        return grad_delta, grad_beta, loss
+
+    # ------------------------------------------------------------------
+    def loss_and_gradient(self, delta_slices, beta_slices, probe,
+                          u_measured, delta_means=None):
+        """Forward + backward in one call (no checkpointing)."""
+        u_exit, wf = self.forward(delta_slices, beta_slices, probe,
+                                  delta_means=delta_means,
+                                  store_wavefields=True)
+        gd, gb, loss = self.gradient(wf, u_measured, delta_means=delta_means)
+        return loss, gd, gb, u_exit
+
+    # ------------------------------------------------------------------
+    def loss_and_gradient_checkpointed(self, delta_slices, beta_slices,
+                                       probe, u_measured,
+                                       delta_means=None,
+                                       n_checkpoints: Optional[int] = None):
+        """
+        Memory-efficient forward + backward via gradient checkpointing.
+
+        Divides the slice stack into ``n_checkpoints`` segments.  Only the
+        entry wavefield of each segment is stored; within-segment forward
+        passes are recomputed during the backward pass.
+
+        Memory: O(n_checkpoints × N²)  instead of O(N_slices × N²).
+        Compute: ~2× the forward-pass cost (one extra partial forward pass
+                 per segment).
+
+        Parameters
+        ----------
+        n_checkpoints : int, optional
+            Overrides ``self.n_checkpoints`` for this call.
+        """
+        if isinstance(delta_slices, np.ndarray):
+            delta_slices = torch.from_numpy(delta_slices)
+        if isinstance(beta_slices, np.ndarray):
+            beta_slices = torch.from_numpy(beta_slices)
+
+        n_slices = delta_slices.shape[0]
+        if delta_means is None:
+            delta_means = torch.zeros(n_slices, dtype=torch.float32)
+        elif isinstance(delta_means, np.ndarray):
+            delta_means = torch.from_numpy(delta_means)
+
+        ncp   = n_checkpoints if n_checkpoints is not None else self.n_checkpoints
+        seg   = max(1, n_slices // ncp)               # slices per segment
+        n_seg = math.ceil(n_slices / seg)
+
+        dz    = self.slice_thickness
+        scale = self.k0 * dz
+
+        # One sync to get all delta_means on CPU (avoids per-slab sync in loop)
+        if isinstance(delta_means, torch.Tensor) and delta_means.device.type != 'cpu':
+            _dm = delta_means.detach().cpu().tolist()
+        elif isinstance(delta_means, torch.Tensor):
+            _dm = delta_means.tolist()
+        else:
+            _dm = [float(x) for x in delta_means]
+
+        # ── Forward pass: store only segment-entry wavefields ──────────
+        checkpoints: List[torch.Tensor] = []
+        U = self._to(probe).clone()
+
+        for s in range(n_seg):
+            checkpoints.append(U.clone())
+            j0 = s * seg
+            j1 = min((s + 1) * seg, n_slices)
+            for j in range(j0, j1):
+                T_j = self.transmission(delta_slices[j], beta_slices[j])
+                U   = self._prop.propagate(T_j * U, dz, delta_mean=_dm[j])
+
+        u_meas_t = self._to(u_measured)
+        residual = U - u_meas_t
+        loss     = 0.5 * float(residual.abs().pow(2).sum().cpu())
+
+        grad_delta = torch.zeros((n_slices,) + self.shape,
+                                 dtype=torch.float32, device=self.device)
+        grad_beta  = torch.zeros((n_slices,) + self.shape,
+                                 dtype=torch.float32, device=self.device)
+        r = residual.clone()
+
+        # ── Backward pass: recompute each segment on the fly ───────────
+        for s in range(n_seg - 1, -1, -1):
+            j0 = s * seg
+            j1 = min((s + 1) * seg, n_slices)
+
+            # Recompute forward within segment (cheap)
+            U_s = checkpoints[s].clone()
+            W_seg: List[torch.Tensor] = []
+            T_seg: List[torch.Tensor] = []
+            for j in range(j0, j1):
+                T_j = self.transmission(delta_slices[j], beta_slices[j])
+                W_j = T_j * U_s
+                U_s = self._prop.propagate(W_j, dz, delta_mean=_dm[j])
+                W_seg.append(W_j)
+                T_seg.append(T_j)
+
+            # Backward through segment
+            for j in range(j1 - 1, j0 - 1, -1):
+                jj  = j - j0
+                s_j = self._prop.propagate_adjoint(r, dz, delta_mean=_dm[j])
+                cross         = W_seg[jj] * s_j.conj()
+                grad_delta[j] =  scale * cross.imag
+                grad_beta[j]  = -scale * cross.real
+                r = T_seg[jj].conj() * s_j
+
+        return loss, grad_delta, grad_beta
+
+
+# ---------------------------------------------------------------------------
+# Volume ↔ slice utilities  (torch versions of the numpy helpers)
+# ---------------------------------------------------------------------------
+
+def extract_slices_torch(
+    delta_vol: torch.Tensor,
+    beta_vol:  torch.Tensor,
+    theta_deg: float,
+    n_slices:  Optional[int] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Torch version of ``extract_slices_from_volume``.
+
+    Rotates the 3-D volume in the (x, z) plane and extracts ``n_slices``
+    perpendicular 2-D slabs.
+
+    Parameters
+    ----------
+    delta_vol : torch.Tensor, float32, shape (Nz, Ny, Nx)
+    beta_vol  : torch.Tensor, float32, shape (Nz, Ny, Nx)
+    theta_deg : float
+    n_slices  : int, optional
+
+    Returns
+    -------
+    delta_slices : torch.Tensor, shape (n_slices, Ny, Nx)
+    beta_slices  : torch.Tensor, shape (n_slices, Ny, Nx)
+    delta_means  : torch.Tensor, shape (n_slices,)
+    """
+    Nz, Ny, Nx = delta_vol.shape
+
+    delta_rot = rotate_volume_torch(delta_vol, theta_deg)
+    beta_rot  = rotate_volume_torch(beta_vol,  theta_deg)
+
+    if n_slices is None or n_slices == Nz:
+        delta_slices = delta_rot
+        beta_slices  = beta_rot
+    else:
+        k = Nz // n_slices
+        if k == 0:
+            raise ValueError(
+                f"n_slices={n_slices} > Nz={Nz}: cannot have more slices than z-pixels.")
+        n_use = k * n_slices
+        delta_slices = delta_rot[:n_use].reshape(n_slices, k, Ny, Nx).mean(dim=1)
+        beta_slices  = beta_rot[:n_use].reshape(n_slices, k, Ny, Nx).mean(dim=1)
+
+    delta_means = delta_slices.mean(dim=(1, 2))   # (n_slices,)
+    return delta_slices, beta_slices, delta_means
+
+
+def scatter_gradient_torch(
+    grad_delta_slices: torch.Tensor,
+    grad_beta_slices:  torch.Tensor,
+    theta_deg:         float,
+    volume_shape:      Tuple[int, int, int],
+    n_slices:          Optional[int] = None,
+    compute_beta:      bool = True,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """
+    Torch version of ``scatter_gradient_to_volume``.
+
+    Adjoint of :func:`extract_slices_torch`: back-rotates per-slice
+    gradient maps into the 3-D volume.
+
+    Parameters
+    ----------
+    grad_delta_slices : torch.Tensor, shape (n_slices, Ny, Nx)
+    grad_beta_slices  : torch.Tensor, shape (n_slices, Ny, Nx)
+    theta_deg : float
+    volume_shape : tuple (Nz, Ny, Nx)
+    n_slices : int, optional
+    compute_beta : bool
+        If False, skip the beta back-rotation entirely and return
+        ``(grad_delta_vol, None)``.  This avoids one full-volume rotation
+        (and its grid_sample transients) per angle when beta is frozen ---
+        a significant VRAM saving for large volumes.
+
+    Returns
+    -------
+    grad_delta_vol : torch.Tensor, shape (Nz, Ny, Nx)
+    grad_beta_vol  : torch.Tensor or None
+    """
+    Nz, Ny, Nx = volume_shape
+    device = grad_delta_slices.device
+
+    def _to_full(slices):
+        if n_slices is not None and n_slices < Nz:
+            k     = Nz // n_slices
+            n_use = k * n_slices
+            full = slices.repeat_interleave(k, dim=0) / k   # spread over k layers
+            if n_use < Nz:
+                pad = torch.zeros(Nz - n_use, Ny, Nx,
+                                  dtype=full.dtype, device=device)
+                full = torch.cat([full, pad], dim=0)
+            return full
+        return slices
+
+    # Back-rotate by −theta (adjoint of the forward rotation)
+    grad_delta_vol = rotate_volume_torch(_to_full(grad_delta_slices), -theta_deg)
+    if not compute_beta:
+        return grad_delta_vol, None
+    grad_beta_vol = rotate_volume_torch(_to_full(grad_beta_slices), -theta_deg)
+    return grad_delta_vol, grad_beta_vol
+
+
+# ---------------------------------------------------------------------------
+# TV regulariser
+# ---------------------------------------------------------------------------
+
+def tv_grad_torch(vol: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
+    """
+    Gradient of the smooth isotropic 3-D total-variation functional.
+
+    Computes  ∇R_TV(v) = −div(∇v / |∇v|_ε)  where
+
+        R_TV(v) = Σ_r  √(|∇v(r)|² + ε)
+        |∇v|_ε  = √(gz² + gy² + gx² + ε)
+
+    Torch mirror of the NumPy ``_tv_gradient_3d`` in ``twopass.py``;
+    both use the same isotropic formula and the same ``eps`` convention
+    so that switching between the NumPy and PyTorch backends produces
+    identical results.
+
+    Forward differences with zero-Neumann boundary conditions are used
+    for ∇v; their adjoint (backward differences) gives −div(p).
+
+    Parameters
+    ----------
+    vol : torch.Tensor, real float32, shape (Nz, Ny, Nx)
+    eps : float
+        Smoothing constant that makes R_TV differentiable at flat regions.
+        Default 1e-8 (matches ``_tv_gradient_3d``).
+
+    Returns
+    -------
+    torch.Tensor, same shape, dtype, and device as ``vol``
+    """
+    # --- forward differences with zero-Neumann BC (last diff = 0) ----------
+    gz = torch.zeros_like(vol); gz[:-1]       = vol[1:]       - vol[:-1]
+    gy = torch.zeros_like(vol); gy[:, :-1, :] = vol[:, 1:, :] - vol[:, :-1, :]
+    gx = torch.zeros_like(vol); gx[:, :, :-1] = vol[:, :, 1:] - vol[:, :, :-1]
+
+    # --- smoothed local norm + TV value (free: just sum the norm tensor) ---
+    norm = torch.sqrt(gz ** 2 + gy ** 2 + gx ** 2 + eps)
+    tv_val = float(norm.sum())
+    gz = gz / norm
+    gy = gy / norm
+    gx = gx / norm
+
+    # --- adjoint backward differences  →  −div(p) = ∇R_TV -----------------
+    # (D_d^* p)_i = p_{i-1} − p_i   with  p_{-1} = 0
+    #
+    # z-axis
+    grad = torch.empty_like(vol)
+    grad[0,  :, :]  = -gz[0,  :, :]
+    grad[1:, :, :]  =  gz[:-1, :, :] - gz[1:, :, :]
+    # y-axis (add in-place)
+    grad[:,  0, :]  = grad[:,  0, :]  - gy[:,  0, :]
+    grad[:, 1:, :]  = grad[:, 1:, :] + gy[:, :-1, :] - gy[:, 1:, :]
+    # x-axis (add in-place)
+    grad[:, :,  0]  = grad[:, :,  0]  - gx[:, :,  0]
+    grad[:, :, 1:]  = grad[:, :, 1:]  + gx[:, :, :-1] - gx[:, :, 1:]
+
+    return grad, tv_val
+
+
+# ---------------------------------------------------------------------------
+# Minimal Adam optimiser
+# ---------------------------------------------------------------------------
+
+class TorchAdamState:
+    """
+    Lightweight Adam optimiser for a single float32 tensor parameter.
+
+    Mirrors the NumPy ``_Adam`` class in the tutorial but keeps all state
+    on ``device`` for zero-copy updates.
+
+    Parameters
+    ----------
+    shape : tuple
+    lr    : float   learning rate (can be updated between steps via ``self.lr``)
+    b1    : float   first-moment decay  (default 0.9)
+    b2    : float   second-moment decay (default 0.999)
+    eps   : float   numerical stabiliser (default 1e-8)
+    device : torch.device
+    """
+
+    def __init__(self, shape: tuple, lr: float = 1e-3,
+                 b1: float = 0.9, b2: float = 0.999, eps: float = 1e-8,
+                 device: Optional[torch.device] = None) -> None:
+        self.lr  = lr
+        self.b1  = b1
+        self.b2  = b2
+        self.eps = eps
+        self.t   = 0
+        kw = {"dtype": torch.float32, "device": device}
+        self.m = torch.zeros(shape, **kw)
+        self.v = torch.zeros(shape, **kw)
+
+    def step(self, param: torch.Tensor, grad: torch.Tensor) -> torch.Tensor:
+        """In-place Adam update of ``param``.  Returns ``param``."""
+        self.t += 1
+        self.m = self.b1 * self.m + (1.0 - self.b1) * grad
+        self.v = self.b2 * self.v + (1.0 - self.b2) * grad ** 2
+        m_hat  = self.m / (1.0 - self.b1 ** self.t)
+        v_hat  = self.v / (1.0 - self.b2 ** self.t)
+        param -= self.lr * m_hat / (torch.sqrt(v_hat) + self.eps)
+        return param

--- a/toupy/tomo/twopass.py
+++ b/toupy/tomo/twopass.py
@@ -1,0 +1,702 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Two-pass tomographic reconstruction with multislice wave-propagation correction.
+
+Overview
+--------
+Standard ptychographic X-ray CT (PXCT) reconstructs a 3-D refractive-index
+volume in two sequential steps that are each internally consistent:
+
+  1. Ptychography (2-D, per projection angle) → complex exit waves
+  2. FBP (Filtered Back-Projection, assuming straight-ray line integrals)
+
+This works beautifully for hard X-rays and thin/low-Z samples, where the
+projection approximation is excellent.  When the sample is thick enough or
+energetic enough that diffraction *within* the sample is non-negligible,
+however, the chain breaks down:
+
+  * FBP assumes straight-ray propagation (projection approximation).
+  * Multislice ptychography correctly models bent rays but uses the
+    vacuum Fresnel propagator between slices — inconsistent with a
+    refracting medium.
+  * Feeding multislice-derived projections into FBP is a model mismatch.
+
+The :class:`TwoPassReconstructor` resolves these issues:
+
+**Pass 1 — FBP initialisation**
+    Standard filtered back-projection of the phase (and optionally
+    amplitude) projections from ptychography, using existing Toupy
+    infrastructure.  This delivers a high-quality initial guess for
+    δ(r) and β(r) in O(N³ log N) time.
+
+**Pass 2 — Multislice refinement**
+    Iterative gradient-descent optimisation of the 3-D volume using the
+    multislice forward model with a matter-corrected Fresnel propagator.
+    At each outer iteration:
+
+      a. The mean refractive index per depth slice δ̄(z) is computed from
+         the current 3-D estimate → used to build the matter-corrected
+         propagator (eliminates the vacuum-propagator inconsistency).
+      b. For each projection angle θ, the 3-D volume is rotated into the
+         beam frame, the multislice forward model propagates the probe
+         through the rotated slices, and the simulated exit wave is
+         compared to the measured one.
+      c. The adjoint multislice (exact gradient of the squared-residual
+         loss) accumulates the contribution of angle θ into the 3-D
+         gradient volume (correct even for non-straight rays).
+      d. The 3-D volume is updated with an Adam optimiser step.
+      e. Optional: non-negativity projection (δ, β ≥ 0).
+
+Since Pass 1 already delivers a near-correct solution, Pass 2 is a
+*perturbative* correction — convergence is fast and the ill-posedness
+of a cold-start multislice inversion is avoided.  The 3-D
+parameterisation (voxel grid) also eliminates the slice-decomposition
+ambiguity that plagues multislice ptychography.
+
+Quick start
+-----------
+::
+
+    rec = TwoPassReconstructor(
+        wavelength  = 0.1e-9,    # 0.1 nm  (12.4 keV)
+        pixel_size  = 5e-9,      # 5 nm voxel
+        n_slices    = 20,        # slices per projection
+    )
+
+    # Pass 1: FBP
+    delta_vol, beta_vol = rec.pass1(phase_stack, theta, **fbp_params)
+
+    # Pass 2: multislice refinement
+    delta_vol, beta_vol = rec.pass2(
+        u_measured_stack, theta, delta_vol, beta_vol,
+        probe       = ptychographic_probe,  # or None for plane wave
+        n_iter      = 30,
+        lr          = 5e-4,
+        matter_correction = True,
+    )
+
+Parameters guide
+----------------
+n_slices
+    How many thin slabs to use per projection.  The physical slice
+    thickness becomes ``Nz * pixel_size / n_slices``.  More slices →
+    better diffraction accuracy but higher memory and compute cost.
+    Good starting value: 20–40.  For hard X-rays with pixel_size ≈ 5 nm
+    and Nz = 256, n_slices = 20 gives Δz = 64 nm per slice.
+lr (learning rate)
+    Step size for the Adam optimiser.  Start with 1e-4 to 1e-3.
+    Values > 1e-2 may cause instability.
+matter_correction
+    If True (default), use the matter-corrected Fresnel propagator
+    instead of the vacuum propagator.  Disable only for debugging.
+regularisation
+    ``"none"`` (no regularisation),
+    ``"positivity"`` (clip δ, β to [0, +∞) after each step; default),
+    or ``"tv"`` (smooth isotropic total-variation added to the gradient
+    before Adam, followed by positivity clip; weight set by ``tv_weight``).
+"""
+
+# standard library
+import time
+import warnings
+
+# third-party
+import numpy as np
+from scipy.ndimage import rotate as ndimage_rotate
+
+# local toupy
+from ..utils import tqdm
+from .iradon import backprojector
+from .tomorecons import tomo_recons
+from .multislice import (
+    MultisliceEngine,
+    extract_slices_from_volume,
+    scatter_gradient_to_volume,
+    mean_refractive_index_profile,
+)
+
+__all__ = ["TwoPassReconstructor"]
+
+
+# ---------------------------------------------------------------------------
+# TV regularisation helper
+# ---------------------------------------------------------------------------
+
+def _tv_gradient_3d(vol, eps=1e-8):
+    """
+    Gradient of the smooth isotropic 3-D total-variation functional.
+
+    Computes  ∇R_TV(v) = −div(∇v / |∇v|_ε)  where
+
+        R_TV(v) = Σ_r  √(|∇v(r)|² + ε)
+        |∇v|_ε  = √(gz² + gy² + gx² + ε)
+
+    Forward differences with zero-Neumann boundary conditions are used
+    for the gradient ∇v; their adjoint (backward differences) gives −div.
+
+    Parameters
+    ----------
+    vol : ndarray, real, shape (Nz, Ny, Nx)
+    eps : float, optional
+        Smoothing constant that makes R_TV differentiable at flat regions.
+        Typical value: 1e-8.  Decrease for sharper edges; increase for
+        more stability near zero.
+
+    Returns
+    -------
+    grad : ndarray, same shape as vol
+        ∇R_TV(vol).  Scale by ``mu_tv`` before adding to the data gradient.
+    tv_val : float
+        R_TV(vol) = Σ_r |∇v(r)|_ε  (useful for monitoring).
+
+    Notes
+    -----
+    Boundary conditions: zero-Neumann (zero normal derivative at all faces).
+    This is the natural BC for TV denoising of a finite domain; it avoids
+    artificial gradients at the volume edges.
+
+    Memory: 3 extra float arrays of the same shape as *vol* (gz, gy, gx)
+    plus one float array for the output gradient.  Peak ≈ 4 × sizeof(vol).
+    """
+    # --- forward differences with zero-Neumann BC (last diff = 0) ----------
+    gz = np.zeros_like(vol)
+    gz[:-1]      = vol[1:]      - vol[:-1]
+
+    gy = np.zeros_like(vol)
+    gy[:, :-1, :] = vol[:, 1:, :] - vol[:, :-1, :]
+
+    gx = np.zeros_like(vol)
+    gx[:, :, :-1] = vol[:, :, 1:] - vol[:, :, :-1]
+
+    # --- smoothed local norm + TV value (free, same loop) ------------------
+    norm = np.sqrt(gz ** 2 + gy ** 2 + gx ** 2 + eps)
+    tv_val = float(np.sum(norm))
+
+    # --- normalise in-place to save memory ---------------------------------
+    gz /= norm
+    gy /= norm
+    gx /= norm
+
+    # --- adjoint backward differences  →  -div(p) = ∇R_TV -----------------
+    # (D_d^* p)_i = p_{i-1} − p_i   with  p_{-1} = 0
+    #
+    # z-axis contribution
+    grad = np.empty_like(vol)
+    grad[0,  :, :]  = -gz[0,  :, :]
+    grad[1:, :, :]  =  gz[:-1, :, :] - gz[1:, :, :]
+
+    # y-axis contribution (add in-place)
+    grad[:,  0, :]  -= gy[:,  0, :]
+    grad[:, 1:, :]  += gy[:, :-1, :] - gy[:, 1:, :]
+
+    # x-axis contribution (add in-place)
+    grad[:, :,  0]  -= gx[:, :,  0]
+    grad[:, :, 1:]  += gx[:, :, :-1] - gx[:, :, 1:]
+
+    return grad, tv_val
+
+
+# ---------------------------------------------------------------------------
+# Adam optimiser (minimal, dependency-free implementation)
+# ---------------------------------------------------------------------------
+
+class _AdamState:
+    """Per-variable Adam momentum state."""
+
+    def __init__(self, shape, lr=1e-3, beta1=0.9, beta2=0.999, eps=1e-8):
+        self.lr    = lr
+        self.beta1 = beta1
+        self.beta2 = beta2
+        self.eps   = eps
+        self.m     = np.zeros(shape, dtype=np.float64)   # first moment
+        self.v     = np.zeros(shape, dtype=np.float64)   # second moment
+        self.t     = 0                                    # step counter
+
+    def step(self, param, grad):
+        """
+        Update ``param`` in-place with an Adam step.
+
+        Returns
+        -------
+        param : ndarray  (updated in-place)
+        """
+        self.t += 1
+        self.m = self.beta1 * self.m + (1.0 - self.beta1) * grad
+        self.v = self.beta2 * self.v + (1.0 - self.beta2) * grad ** 2
+        m_hat  = self.m / (1.0 - self.beta1 ** self.t)
+        v_hat  = self.v / (1.0 - self.beta2 ** self.t)
+        param -= self.lr * m_hat / (np.sqrt(v_hat) + self.eps)
+        return param
+
+
+# ---------------------------------------------------------------------------
+# Two-pass reconstructor
+# ---------------------------------------------------------------------------
+
+class TwoPassReconstructor:
+    """
+    Two-pass tomographic reconstruction combining FBP initialisation with
+    multislice wave-propagation refinement.
+
+    Parameters
+    ----------
+    wavelength : float
+        X-ray wavelength [m].
+    pixel_size : float
+        Isotropic voxel side length [m].
+    n_slices : int, optional
+        Number of multislice slabs per projection angle.  Default 20.
+    verbose : bool, optional
+        Print progress during Pass 2.  Default True.
+    """
+
+    def __init__(self, wavelength, pixel_size, n_slices=20, verbose=True):
+        self.wavelength  = float(wavelength)
+        self.pixel_size  = float(pixel_size)
+        self.n_slices    = int(n_slices)
+        self.verbose     = bool(verbose)
+
+    # ==================================================================
+    # Pass 1: FBP reconstruction
+    # ==================================================================
+
+    def pass1(self, phase_stack, theta, beta_stack=None, **fbp_params):
+        """
+        Pass 1: FBP reconstruction from projected phase (and optionally
+        projected amplitude attenuation) maps.
+
+        This is a thin wrapper around :func:`toupy.tomo.tomo_recons`; all
+        keyword arguments are forwarded to it unchanged.
+
+        Parameters
+        ----------
+        phase_stack : ndarray, real, shape (n_angles, Ny, Nx)
+            Projected phase maps φ_θ(x,y) = −k₀∫δ dz [radians].
+            One 2-D image per projection angle.
+        theta : array_like, shape (n_angles,)
+            Projection angles [degrees].
+        beta_stack : ndarray, real, shape (n_angles, Ny, Nx), optional
+            Projected amplitude attenuation maps −k₀∫β dz [nepers].
+            If provided, a separate FBP is run to recover β(r).
+        **fbp_params
+            Parameters forwarded to :func:`toupy.tomo.tomo_recons`,
+            e.g. ``filtertype``, ``freqcutoff``, ``circle``, ``derivatives``.
+
+        Returns
+        -------
+        delta_vol : ndarray, real, shape (Nz, Ny, Nx)
+            Refractive-index decrement volume from FBP.
+            δ(r) = −φ_FBP(r) / k₀  (divided by k₀ after reconstruction).
+        beta_vol : ndarray, real, shape (Nz, Ny, Nx)
+            Absorption volume.  All-zeros if ``beta_stack`` is None.
+
+        Notes
+        -----
+        The FBP output is the projected *phase* (or attenuation), not yet
+        divided by k₀.  The conversion φ_3D(r) → δ(r) = −φ_3D(r)/k₀ is
+        performed here.  Ensure that ``phase_stack`` carries the correct
+        sign convention (negative for refracting matter).
+        """
+        n_angles, Ny, Nx = phase_stack.shape
+        theta = np.asarray(theta, dtype=np.float64)
+
+        # Default FBP parameters compatible with Toupy conventions
+        default_params = dict(
+            algorithm       = "FBP",
+            filtertype      = "ram-lak",
+            freqcutoff      = 1.0,
+            circle          = True,
+            derivatives     = False,
+            calc_derivatives= False,
+            weight_angles   = False,
+            opencl          = False,
+        )
+        default_params.update(fbp_params)
+
+        if self.verbose:
+            print("Pass 1 — FBP reconstruction")
+            t0 = time.time()
+
+        # Reconstruct δ slice-by-slice from phase sinograms
+        # Phase stack shape: (n_angles, Ny, Nx) → sinogram shape: (Nx, n_angles)
+        # (Toupy convention: sinogram[detector_bin, angle])
+        sinogram0 = np.transpose(phase_stack[:, 0, :])  # slice 0 for size estimation
+        recons0 = tomo_recons(sinogram0, theta, **default_params)
+        Nz_recons, _ = recons0.shape
+
+        # We reconstruct all horizontal slices (axis 1 = y = row)
+        delta_vol = np.zeros((Ny, Nz_recons, Nz_recons), dtype=np.float32)
+        delta_vol[0] = recons0
+
+        for iy in tqdm(range(1, Ny), desc="Pass 1 FBP (δ)", disable=not self.verbose):
+            sino = np.transpose(phase_stack[:, iy, :])
+            delta_vol[iy] = tomo_recons(sino, theta, **default_params)
+
+        # Convert from projected phase to δ: φ_FBP = −k₀ · δ_FBP · pixel_size
+        # ⟹  δ = −φ_FBP / (k₀ · pixel_size)
+        k0  = 2.0 * np.pi / self.wavelength
+        delta_vol = (-delta_vol / (k0 * self.pixel_size)).astype(np.float64)
+        np.clip(delta_vol, 0.0, None, out=delta_vol)   # physical constraint δ ≥ 0
+
+        # Reconstruct β if amplitude projections are given
+        beta_vol = np.zeros_like(delta_vol)
+        if beta_stack is not None:
+            for iy in tqdm(range(Ny), desc="Pass 1 FBP (β)",
+                           disable=not self.verbose):
+                sino = np.transpose(beta_stack[:, iy, :])
+                beta_vol[iy] = tomo_recons(sino, theta, **default_params)
+            beta_vol = (-beta_vol / (k0 * self.pixel_size)).astype(np.float64)
+            np.clip(beta_vol, 0.0, None, out=beta_vol)
+
+        # FBP returns (Ny, Nz, Nx) — height · depth · transverse.
+        # The multislice engine expects (Nz, Ny, Nx) — depth · height · transverse.
+        # Transpose to the canonical convention used throughout Pass 2.
+        delta_vol = np.ascontiguousarray(np.transpose(delta_vol, (1, 0, 2)))
+        beta_vol  = np.ascontiguousarray(np.transpose(beta_vol,  (1, 0, 2)))
+
+        if self.verbose:
+            print(f"  Pass 1 done in {time.time()-t0:.1f} s.  "
+                  f"δ: [{delta_vol.min():.3e}, {delta_vol.max():.3e}]")
+
+        return delta_vol, beta_vol
+
+    # ==================================================================
+    # Pass 2: multislice refinement
+    # ==================================================================
+
+    def pass2(
+        self,
+        u_measured_stack,
+        theta,
+        delta_vol,
+        beta_vol,
+        probe             = None,
+        n_iter            = 30,
+        lr                = 1e-3,
+        matter_correction = True,
+        regularisation    = "positivity",
+        tv_weight         = 1e-3,
+        batch_size        = None,
+        callback          = None,
+    ):
+        """
+        Pass 2: iterative multislice wave-propagation refinement.
+
+        Uses the Pass-1 volume as initialisation and refines it by
+        minimising the squared residual between simulated and measured
+        exit waves, using the multislice forward model with an optional
+        matter-corrected Fresnel propagator.
+
+        Parameters
+        ----------
+        u_measured_stack : ndarray, complex, shape (n_angles, Ny, Nx)
+            Measured complex exit waves, one per projection angle.
+            Typically the ptychographic reconstructions divided by the
+            probe (i.e. the complex transmission function of the object).
+        theta : array_like, shape (n_angles,)
+            Projection angles in degrees (same order as ``u_measured_stack``).
+        delta_vol : ndarray, real, shape (Nz, Ny, Nx)
+            Initial δ(r) volume from Pass 1.  Modified in-place and returned.
+        beta_vol : ndarray, real, shape (Nz, Ny, Nx)
+            Initial β(r) volume from Pass 1.  Modified in-place and returned.
+        probe : ndarray, complex, shape (Ny, Nx), optional
+            Incident probe wavefield.  If None, a unit plane wave is used.
+        n_iter : int, optional
+            Number of outer (volume-update) iterations.  Default 30.
+        lr : float, optional
+            Adam learning rate.  Default 1e-3.
+        matter_correction : bool, optional
+            Use the matter-corrected Fresnel propagator.  Default True.
+        regularisation : str, optional
+            ``"none"``       — no regularisation.
+            ``"positivity"`` — clip δ, β to [0, +∞) after each step.
+            ``"tv"``         — smooth isotropic total-variation penalty added
+                               to the data gradient before the Adam step,
+                               followed by the positivity clip.
+                               See :func:`_tv_gradient_3d` and the
+                               ``tv_weight`` parameter.
+            Default ``"positivity"``.
+        tv_weight : float, optional
+            Weight μ_TV of the TV regularisation term.  Only used when
+            ``regularisation="tv"``.  The combined gradient is
+            ``grad_data + tv_weight * ∇R_TV(vol)``.  A good starting range
+            is 1e-4 to 1e-2; larger values produce smoother volumes at the
+            cost of reduced sharpness.  Default 1e-3.
+        batch_size : int, optional
+            Number of angles to process per gradient-accumulation step
+            (stochastic gradient).  Default None = all angles (full batch).
+        callback : callable, optional
+            Called as ``callback(iteration, loss, delta_vol, beta_vol)``
+            at the end of each iteration.  Useful for monitoring or saving
+            intermediate results.
+
+        Returns
+        -------
+        delta_vol : ndarray, real, shape (Nz, Ny, Nx)
+            Refined refractive-index decrement volume.
+        beta_vol : ndarray, real, shape (Nz, Ny, Nx)
+            Refined absorption volume.
+        history : dict
+            ``history["loss"]``    : list of per-iteration data-fidelity loss.
+            ``history["tv_loss"]`` : list of per-iteration TV values
+                                     (only present when ``regularisation="tv"``).
+            ``history["time"]``    : list of per-iteration wall-clock times [s].
+
+        Notes
+        -----
+        Memory usage
+            Intermediate wavefields (one per slice, per angle in batch)
+            are stored on the CPU as complex128 arrays.  Peak memory per
+            angle ≈ 2 · n_slices · Ny · Nx · 16 bytes.  For a 256² grid
+            with n_slices = 20: ≈ 42 MB per angle.  With batch_size = 5:
+            ≈ 210 MB.  Reduce n_slices or batch_size for large volumes.
+
+        Convergence
+            For hard X-rays, Pass 1 is already very close to the truth
+            and the correction in Pass 2 is small.  Ten to twenty
+            iterations at lr = 1e-3 typically suffice to remove the
+            residual model-mismatch artefacts.
+        """
+        theta   = np.asarray(theta, dtype=np.float64)
+        n_angles, Ny, Nx = u_measured_stack.shape
+        Nz = delta_vol.shape[0]
+
+        # Initialise probe (plane wave if not provided)
+        if probe is None:
+            probe = np.ones((Ny, Nx), dtype=complex)
+        else:
+            probe = np.asarray(probe, dtype=complex)
+
+        # Multislice engine
+        slice_thickness = Nz * self.pixel_size / self.n_slices
+        engine = MultisliceEngine(
+            shape          = (Ny, Nx),
+            pixel_size     = self.pixel_size,
+            wavelength     = self.wavelength,
+            slice_thickness= slice_thickness,
+        )
+
+        # Adam optimiser states for δ and β
+        adam_delta = _AdamState(delta_vol.shape, lr=lr)
+        adam_beta  = _AdamState(beta_vol.shape,  lr=lr)
+
+        # Batch configuration
+        angle_indices = np.arange(n_angles)
+        if batch_size is None:
+            batch_size = n_angles
+
+        history = {"loss": [], "time": []}
+        if regularisation == "tv":
+            history["tv_loss"] = []
+
+        if self.verbose:
+            print(f"\nPass 2 — Multislice refinement")
+            print(f"  n_iter={n_iter}, lr={lr}, n_slices={self.n_slices}, "
+                  f"matter_correction={matter_correction}, "
+                  f"regularisation={regularisation!r}, "
+                  f"batch_size={batch_size}")
+            if regularisation == "tv":
+                print(f"  tv_weight={tv_weight:.2e}")
+            print(f"  slice_thickness = {slice_thickness*1e9:.2f} nm")
+
+        t_total = time.time()
+
+        for it in range(n_iter):
+            t_iter = time.time()
+
+            # Recompute matter-corrected propagator using current volume
+            # (updated once per outer iteration — cheap and sufficient)
+            # delta_means_per_angle is computed inside _angle_gradient
+
+            total_loss  = 0.0
+            grad_delta  = np.zeros_like(delta_vol)
+            grad_beta   = np.zeros_like(beta_vol)
+
+            # Shuffle angles for stochastic gradient
+            batch_idx = np.random.choice(angle_indices, size=batch_size, replace=False)
+
+            for ai in batch_idx:
+                theta_i   = theta[ai]
+                u_meas_i  = u_measured_stack[ai]
+
+                loss_i, gd_i, gb_i = self._angle_gradient(
+                    delta_vol, beta_vol, theta_i,
+                    probe, u_meas_i, engine,
+                    matter_correction=matter_correction,
+                )
+                total_loss += loss_i
+                grad_delta += gd_i
+                grad_beta  += gb_i
+
+            # Normalise data gradient by batch size
+            grad_delta /= batch_size
+            grad_beta  /= batch_size
+
+            # TV regularisation: add μ_TV · ∇R_TV to data gradient
+            # before the Adam step so Adam's adaptive rates scale the
+            # combined gradient consistently.
+            if regularisation == "tv":
+                tv_grad_d, tv_val_d = _tv_gradient_3d(delta_vol)
+                tv_grad_b, tv_val_b = _tv_gradient_3d(beta_vol)
+                grad_delta += tv_weight * tv_grad_d
+                grad_beta  += tv_weight * tv_grad_b
+                del tv_grad_d, tv_grad_b   # free memory promptly
+                history["tv_loss"].append(tv_weight * (tv_val_d + tv_val_b))
+
+            # Adam update
+            adam_delta.step(delta_vol, grad_delta)
+            adam_beta.step( beta_vol,  grad_beta)
+
+            # Positivity projection: δ, β ≥ 0 (physical constraint).
+            # Applied for both "positivity" and "tv" modes.
+            if regularisation in ("positivity", "tv"):
+                np.clip(delta_vol, 0.0, None, out=delta_vol)
+                np.clip(beta_vol,  0.0, None, out=beta_vol)
+
+            elapsed = time.time() - t_iter
+            history["loss"].append(total_loss)
+            history["time"].append(elapsed)
+
+            if self.verbose:
+                tv_str = (f"  tv={history['tv_loss'][-1]:.3e}"
+                          if regularisation == "tv" else "")
+                print(f"  Iter {it+1:3d}/{n_iter}  loss={total_loss:.4e}"
+                      f"{tv_str}  t={elapsed:.1f}s  "
+                      f"δ∈[{delta_vol.min():.2e},{delta_vol.max():.2e}]")
+
+            if callback is not None:
+                callback(it + 1, total_loss, delta_vol, beta_vol)
+
+        if self.verbose:
+            print(f"Pass 2 done in {time.time()-t_total:.1f} s total.")
+
+        return delta_vol, beta_vol, history
+
+    # ==================================================================
+    # Internal helpers
+    # ==================================================================
+
+    def _angle_gradient(self, delta_vol, beta_vol, theta_deg,
+                        probe, u_measured, engine, matter_correction=True):
+        """
+        Forward + adjoint pass for a single projection angle.
+
+        Extracts oblique slices from the 3-D volume at ``theta_deg``,
+        runs the multislice forward and backward passes, then back-rotates
+        the slice gradients into the 3-D volume gradient.
+
+        Parameters
+        ----------
+        delta_vol : ndarray (Nz, Ny, Nx)
+        beta_vol  : ndarray (Nz, Ny, Nx)
+        theta_deg : float
+        probe : ndarray, complex (Ny, Nx)
+        u_measured : ndarray, complex (Ny, Nx)
+        engine : MultisliceEngine
+        matter_correction : bool
+
+        Returns
+        -------
+        loss : float
+        grad_delta_vol : ndarray (Nz, Ny, Nx)
+        grad_beta_vol  : ndarray (Nz, Ny, Nx)
+        """
+        # 1. Extract slices perpendicular to the beam at this angle
+        delta_slices, beta_slices, delta_means = extract_slices_from_volume(
+            delta_vol, beta_vol, theta_deg, n_slices=self.n_slices
+        )
+
+        # 2. Build matter-corrected propagator (or vacuum)
+        d_means = delta_means if matter_correction else None
+
+        # 3. Forward + adjoint multislice
+        loss, grad_delta_slices, grad_beta_slices, _ = engine.loss_and_gradient(
+            delta_slices, beta_slices, probe, u_measured, delta_means=d_means
+        )
+
+        # 4. Back-rotate slice gradients → 3-D volume gradients
+        grad_delta_vol, grad_beta_vol = scatter_gradient_to_volume(
+            grad_delta_slices, grad_beta_slices,
+            theta_deg, delta_vol.shape, n_slices=self.n_slices,
+        )
+
+        return loss, grad_delta_vol, grad_beta_vol
+
+    # ==================================================================
+    # Diagnostics / utilities
+    # ==================================================================
+
+    def simulate_exit_wave(self, delta_vol, beta_vol, theta_deg,
+                           probe=None, matter_correction=True):
+        """
+        Simulate the exit wave at a given projection angle.
+
+        Useful for assessing convergence: compare with the measured exit
+        wave to see how well the current volume explains the data.
+
+        Parameters
+        ----------
+        delta_vol : ndarray (Nz, Ny, Nx)
+        beta_vol  : ndarray (Nz, Ny, Nx)
+        theta_deg : float
+        probe : ndarray, complex (Ny, Nx), optional
+        matter_correction : bool, optional
+
+        Returns
+        -------
+        u_sim : ndarray, complex (Ny, Nx)
+            Simulated exit wave.
+        """
+        Nz, Ny, Nx = delta_vol.shape
+        if probe is None:
+            probe = np.ones((Ny, Nx), dtype=complex)
+
+        slice_thickness = Nz * self.pixel_size / self.n_slices
+        engine = MultisliceEngine(
+            shape          = (Ny, Nx),
+            pixel_size     = self.pixel_size,
+            wavelength     = self.wavelength,
+            slice_thickness= slice_thickness,
+        )
+
+        delta_slices, beta_slices, delta_means = extract_slices_from_volume(
+            delta_vol, beta_vol, theta_deg, n_slices=self.n_slices
+        )
+        d_means = delta_means if matter_correction else None
+        u_sim = engine.forward(delta_slices, beta_slices, probe, delta_means=d_means)
+        return u_sim
+
+    def projection_residuals(self, u_measured_stack, theta,
+                             delta_vol, beta_vol, probe=None,
+                             matter_correction=True):
+        """
+        Compute per-angle residual norms ‖U_sim(θ) − U_meas(θ)‖.
+
+        Parameters
+        ----------
+        u_measured_stack : ndarray, complex (n_angles, Ny, Nx)
+        theta : array_like (n_angles,)
+        delta_vol : ndarray (Nz, Ny, Nx)
+        beta_vol  : ndarray (Nz, Ny, Nx)
+        probe : ndarray, complex (Ny, Nx), optional
+        matter_correction : bool, optional
+
+        Returns
+        -------
+        residuals : ndarray, real, shape (n_angles,)
+        """
+        theta = np.asarray(theta)
+        n_angles, Ny, Nx = u_measured_stack.shape
+        if probe is None:
+            probe = np.ones((Ny, Nx), dtype=complex)
+
+        residuals = np.empty(n_angles)
+        for ai, th in enumerate(tqdm(theta, desc="Computing residuals",
+                                     disable=not self.verbose)):
+            u_sim = self.simulate_exit_wave(delta_vol, beta_vol, th,
+                                            probe=probe,
+                                            matter_correction=matter_correction)
+            residuals[ai] = np.linalg.norm(u_sim - u_measured_stack[ai])
+        return residuals


### PR DESCRIPTION
Adds the two-pass multislice PXCT reconstruction to `toupy.tomo`.

## What it is
An FBP initialisation (Pass 1) refined by Adam gradient descent against a **differentiable multislice wave-propagation forward model** (Pass 2). This recovers δ(r) while accounting for the diffraction / multiple-scattering that plain FBP's projection assumption ignores — a reproducible ~10–11% half-bit resolution gain over FBP on hard-X-ray PXCT data, confirmed to be physics (not a TV-denoising artefact) by a λ_TV=0 control.

## Modules
- **`multislice.py`** — NumPy multislice engine: `MultisliceEngine`, slice extraction, gradient scatter, refractive-index profile.
- **`multislice_torch.py`** — PyTorch/GPU backend (optional; imported behind a `try/except`).
- **`twopass.py`** — `TwoPassReconstructor`: ties Pass 1 (`iradon.backprojector` + `tomorecons.tomo_recons`) to the Pass-2 multislice refinement, with TV regularisation and positivity.
- **`toupy/tomo/__init__.py`** — exports the new modules; the torch backend is guarded so the NumPy path works without torch.

## Scope / safety
- Depends only on existing `toupy.tomo` internals (`backprojector`, `tomo_recons`) and scipy; torch optional.
- **Extracted onto current `dev`**, not merged from the long-lived `twopass` branch (which is based on a pre-0.4.0 ancestor and would otherwise revert 0.4.0 features and re-add removed code).
- Verified: package imports, `TwoPassReconstructor`/`MultisliceEngine` exposed, dev's 0.4.0 API (`tv_recons`, FDK/cone-beam) unaffected.
- **Deliberately out of scope** (separate follow-ups): the `twopass` branch's tutorial/driver scripts, and the FBaP module `filtered_backprop.py`.