### PR TITLE
build: add optional 'torch' extra for the two-pass / FBaP GPU backends

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,3 +51,8 @@ notebook =
 docs =
     sphinx>=5.0
     sphinx-rtd-theme>=1.0
+# Optional PyTorch backend for the two-pass multislice and FBaP GPU paths.
+# Not required: toupy falls back to the pure NumPy backend without torch.
+# Install with:  pip install toupy[torch]
+torch =
+    torch>=1.10.0

--- a/setup.py
+++ b/setup.py
@@ -55,5 +55,11 @@ setuptools.setup(
             "sphinx>=5.0",
             "sphinx-rtd-theme>=1.0",
         ],
+        # Optional PyTorch backend for the two-pass multislice and FBaP GPU
+        # paths.  Not required: toupy falls back to the pure NumPy backend when
+        # torch is absent.  Install with:  pip install toupy[torch]
+        "torch": [
+            "torch>=1.10.0",
+        ],
     },
 )


### PR DESCRIPTION
The two-pass multislice (`multislice_torch.py`) and FBaP (`filtered_backprop.py`) GPU paths use PyTorch — but it's **optional**, so the install config should reflect that.

## Why an extra, not a requirement
`toupy.tomo` guards the torch import (`try/except` in `__init__`, lazy import in FBaP) and falls back to a **pure NumPy backend** when torch is absent. Making torch a hard dependency would add ~2 GB to every install for a feature most users don't need. So it belongs in `extras_require`, not `install_requires`.

## Change
Adds a `torch` extra to **both** `setup.py` (`extras_require`) and `setup.cfg` (`[options.extras_require]`) — kept consistent since the repo declares deps in both:

```
pip install toupy[torch]      # two-pass / FBaP GPU backend
pip install toupy             # unchanged — torch-free, NumPy backend
```

## Verified
- `setup.py` parses; `setup.cfg` exposes the `torch` extra (`torch>=1.10.0`).
- `install_requires` and `requirements.txt` remain torch-free — base install is unchanged.

## Note (not addressed here)
Dependencies are declared in *both* `setup.py` and `setup.cfg`, which is redundant and a maintenance hazard. Consolidating to one (ideally PEP 621 `[project]` in `pyproject.toml`) would be a good separate cleanup.